### PR TITLE
Add multiple astar start states and revise PRM queries

### DIFF
--- a/include/common_robotics_utilities/simple_graph_search.hpp
+++ b/include/common_robotics_utilities/simple_graph_search.hpp
@@ -213,8 +213,11 @@ inline DijkstrasResult PerformDijkstrasAlgorithm(
 
 template<typename NodeValueType>
 inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
-    const simple_graph::Graph<NodeValueType>& graph, const int64_t start_index,
-    const std::function<bool(const int64_t)>& goal_check_fn,
+    const simple_graph::Graph<NodeValueType>& graph,
+    const std::map<int64_t, double>& start_indices,
+    const std::function<bool(
+        const simple_graph::Graph<NodeValueType>&,
+        const int64_t)>& goal_check_fn,
     const std::function<bool(
         const simple_graph::Graph<NodeValueType>&,
         const simple_graph::GraphEdge&)>& edge_validity_check_fn,
@@ -227,13 +230,29 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
     const bool limit_pqueue_duplicates)
 {
   // Enforced sanity checks
-  if (!graph.IndexInRange(start_index))
+  int64_t best_start_meeting_goal_index = -1;
+  double best_start_meeting_goal_cost = std::numeric_limits<double>::infinity();
+  for (const auto& start_index_and_cost : start_indices)
   {
-    throw std::invalid_argument("Start index out of range");
+    const int64_t start_index = start_index_and_cost.first;
+    const double start_cost = start_index_and_cost.second;
+    if (!graph.IndexInRange(start_index))
+    {
+      throw std::invalid_argument("Start index out of range");
+    }
+    if (goal_check_fn(graph, start_index))
+    {
+      if (start_cost < best_start_meeting_goal_cost)
+      {
+        best_start_meeting_goal_index = start_index;
+        best_start_meeting_goal_cost = start_cost;
+      }
+    }
   }
-  if (goal_check_fn(start_index))
+  if (best_start_meeting_goal_index >= 0)
   {
-    return simple_astar_search::AstarIndexResult({start_index}, 0.0);
+    return simple_astar_search::AstarIndexResult(
+        {best_start_meeting_goal_index}, best_start_meeting_goal_cost);
   }
   // Setup
   std::priority_queue<simple_astar_search::AstarPQueueElement,
@@ -248,11 +267,16 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
   // backpointer is the parent index in the provided graph
   simple_astar_search::ExploredList explored;
   // Initialize
-  queue.push(simple_astar_search::AstarPQueueElement(
-      start_index, heuristic_fn(graph, start_index)));
-  if (limit_pqueue_duplicates)
+  for (const auto& start_index_and_cost : start_indices)
   {
-    queue_members_map[start_index] = 0.0;
+    const int64_t start_index = start_index_and_cost.first;
+    const double start_cost = start_index_and_cost.second;
+    queue.push(simple_astar_search::AstarPQueueElement(
+        start_index, start_cost, heuristic_fn(graph, start_index)));
+    if (limit_pqueue_duplicates)
+    {
+      queue_members_map[start_index] = start_cost;
+    }
   }
   // Storage for the goal state (once found)
   OwningMaybe<int64_t> goal_index;
@@ -282,7 +306,7 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
       explored[top_node.NodeID()]
           = simple_astar_search::BackPointerAndCostToCome(top_node);
       // Check if we have reached the goal
-      if (goal_check_fn(top_node.NodeID()))
+      if (goal_check_fn(graph, top_node.NodeID()))
       {
         goal_index = OwningMaybe<int64_t>(top_node.NodeID());
         break;
@@ -338,7 +362,7 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
             // Push onto the pqueue
             queue.push(simple_astar_search::AstarPQueueElement(
                 child_node_index, top_node.NodeID(), child_cost_to_come,
-                         child_value));
+                child_value));
             // Add to the queue member map
             if (limit_pqueue_duplicates)
             {
@@ -352,7 +376,7 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
   if (goal_index)
   {
     return simple_astar_search::ExtractAstarResult(
-        explored, start_index, goal_index.Value());
+        explored, goal_index.Value());
   }
   else
   {
@@ -384,8 +408,11 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
     throw std::invalid_argument("Goal index out of range");
   }
   // Make goal check function
-  const auto goal_check_function = [&] (const int64_t node_index)
+  const auto goal_check_function = [&] (
+      const simple_graph::Graph<NodeValueType>& search_graph,
+      const int64_t node_index)
   {
+    UNUSED(search_graph);
     return (node_index == goal_index);
   };
   // Make heuristic helper function
@@ -395,8 +422,10 @@ inline simple_astar_search::AstarIndexResult PerformLazyAstarSearch(
   {
     return heuristic_fn(search_graph, node_index, goal_index);
   };
+  std::map<int64_t, double> start_indices;
+  start_indices[start_index] = 0.0;
   return PerformLazyAstarSearch<NodeValueType>(
-      graph, start_index, goal_check_function, edge_validity_check_fn,
+      graph, start_indices, goal_check_function, edge_validity_check_fn,
       distance_fn, heuristic_function, limit_pqueue_duplicates);
 }
 

--- a/include/common_robotics_utilities/simple_task_planner.hpp
+++ b/include/common_robotics_utilities/simple_task_planner.hpp
@@ -456,9 +456,12 @@ TaskStateAStarResult<State, Container> PlanTaskStateSequence(
     }
   };
 
+  std::map<int64_t, double> start_ids;
+  start_ids[start_id] = 0.0;
   const bool limit_pqueue_duplicates = true;
+
   const auto astar_solution = simple_astar_search::PerformGenericAstarSearch(
-      start_id, goal_check_function, generate_children_function,
+      start_ids, goal_check_function, generate_children_function,
       edge_validity_check_function, state_distance_function,
       heuristic_function, limit_pqueue_duplicates);
 

--- a/test/planning_test.cpp
+++ b/test/planning_test.cpp
@@ -474,18 +474,16 @@ GTEST_TEST(PlanningTest, Test)
         // Plan with PRM
         std::cout << "PRM Path (" << print::Print(start) << " to "
                   << print::Print(goal) << ")" << std::endl;
-        const auto path
-            = simple_prm_planner::QueryPathSingleStartSingleGoal<Waypoint>(
-                start, goal, loaded_roadmap, WaypointDistance,
-                check_edge_validity_fn, K, false, true, false, true).Path();
+        const auto path = simple_prm_planner::QueryPath<Waypoint>(
+            {start}, {goal}, loaded_roadmap, WaypointDistance,
+            check_edge_validity_fn, K, false, true, false, true).Path();
         check_plan(test_env, {start}, {goal}, path);
         // Plan with Lazy-PRM
         std::cout << "Lazy-PRM Path (" << print::Print(start) << " to "
                   << print::Print(goal) << ")" << std::endl;
-        const auto lazy_path
-            = simple_prm_planner::LazyQueryPathSingleStartSingleGoal<Waypoint>(
-                start, goal, loaded_roadmap, WaypointDistance,
-                check_edge_validity_fn, K, false, true, false, true).Path();
+        const auto lazy_path = simple_prm_planner::LazyQueryPath<Waypoint>(
+            {start}, {goal}, loaded_roadmap, WaypointDistance,
+            check_edge_validity_fn, K, false, true, false, true).Path();
         check_plan(test_env, {start}, {goal}, lazy_path);
         // Plan with A*
         std::cout << "A* Path (" << print::Print(start) << " to "
@@ -589,10 +587,9 @@ GTEST_TEST(PlanningTest, Test)
   const WaypointVector goals = {keypoints.at(2), keypoints.at(3)};
   std::cout << "Multi start/goal PRM Path (" << print::Print(starts) << " to "
             << print::Print(goals) << ")" << std::endl;
-  const auto path
-      = simple_prm_planner::QueryPathMultiStartMultiGoal<Waypoint>(
-          starts, goals, loaded_roadmap, WaypointDistance,
-          check_edge_validity_fn, K, false, true, false).Path();
+  const auto path = simple_prm_planner::QueryPath<Waypoint>(
+      starts, goals, loaded_roadmap, WaypointDistance, check_edge_validity_fn,
+      K, false, true, false).Path();
   check_plan(test_env, starts, goals, path);
 }
 }  // namespace planning_test


### PR DESCRIPTION
- Adds support in A* search implementations for multiple start states
- Uses that support to remove the distinction between single/multi-start and single/multi-goal PRM queries and support the same set of queries for all variants.