### PR TITLE
Add support to print ROS 2 interfaces

### DIFF
--- a/CMakeLists.txt.ros1
+++ b/CMakeLists.txt.ros1
@@ -143,6 +143,10 @@ if(CATKIN_ENABLE_TESTING)
     catkin_add_gtest(voxel_grid_test test/voxel_grid_test.cpp)
     add_dependencies(voxel_grid_test ${PROJECT_NAME})
     target_link_libraries(voxel_grid_test ${PROJECT_NAME})
+
+    catkin_add_gtest(print_test test/print_test.cpp)
+    add_dependencies(print_test ${PROJECT_NAME})
+    target_link_libraries(print_test ${PROJECT_NAME})
 endif()
 
 #############

--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -121,6 +121,9 @@ if(BUILD_TESTING)
 
     ament_add_gtest(voxel_grid_test test/voxel_grid_test.cpp)
     target_link_libraries(voxel_grid_test ${PROJECT_NAME})
+
+    ament_add_gtest(print_test test/print_test.cpp)
+    target_link_libraries(print_test ${PROJECT_NAME})
 endif()
 
 #############

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -19,21 +19,6 @@
 
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 #include <rosidl_runtime_cpp/traits.hpp>
-
-namespace rosidl_generator_traits
-{
-namespace detail
-{
-struct ROSMessagePrinter
-{
-  template <typename T>
-  static std::string Print(const T& message)
-  {
-    return to_yaml(message);
-  }
-};
-}  // namespace detail
-}  // namespace rosidl_generator_traits
 #endif
 
 namespace common_robotics_utilities
@@ -42,6 +27,16 @@ namespace print
 {
 namespace detail
 {
+#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+struct ROSMessagePrinter
+{
+  template <typename T>
+  static std::string Print(const T& message)
+  {
+    return to_yaml(message);
+  }
+};
+#endif
 struct GenericPrinter
 {
   template <typename T>
@@ -65,8 +60,7 @@ inline std::string Print(const T& toprint,
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
   using Printer = typename std::conditional<
       rosidl_generator_traits::is_message<T>::value,
-      rosidl_generator_traits::detail::ROSMessagePrinter,
-      detail::GenericPrinter>::type;
+      detail::ROSMessagePrinter, detail::GenericPrinter>::type;
 #else
   using Printer = detail::GenericPrinter;
 #endif

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -19,10 +19,19 @@
 
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 #include <rosidl_runtime_cpp/traits.hpp>
+
 namespace rosidl_generator_traits
 {
-template<typename T>
-std::string to_yaml(const T& value);
+namespace detail
+{
+struct ROSMessagePrinter {
+  template <typename T>
+  static std::string Print(const T& message)
+  {
+    return to_yaml(message);
+  }
+};
+}  // namespace detail
 }  // namespace rosidl_generator_traits
 #endif
 
@@ -32,15 +41,6 @@ namespace print
 {
 namespace detail
 {
-#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
-struct ROSMessagePrinter {
-  template <typename T>
-  static std::string Print(const T& message)
-  {
-    return rosidl_generator_traits::to_yaml(message);
-  }
-};
-#endif
 struct GenericPrinter
 {
   template <typename T>
@@ -64,7 +64,8 @@ inline std::string Print(const T& toprint,
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
   using Printer = typename std::conditional<
     rosidl_generator_traits::is_message<T>::value,
-    detail::ROSMessagePrinter, detail::GenericPrinter>::type;
+    rosidl_generator_traits::detail::ROSMessagePrinter,
+    detail::GenericPrinter>::type;
 #else
   using Printer = detail::GenericPrinter;
 #endif

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -63,9 +63,9 @@ inline std::string Print(const T& toprint,
   UNUSED(separator);
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
   using Printer = typename std::conditional<
-    rosidl_generator_traits::is_message<T>::value,
-    rosidl_generator_traits::detail::ROSMessagePrinter,
-    detail::GenericPrinter>::type;
+      rosidl_generator_traits::is_message<T>::value,
+      rosidl_generator_traits::detail::ROSMessagePrinter,
+      detail::GenericPrinter>::type;
 #else
   using Printer = detail::GenericPrinter;
 #endif

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -24,7 +24,8 @@ namespace rosidl_generator_traits
 {
 namespace detail
 {
-struct ROSMessagePrinter {
+struct ROSMessagePrinter
+{
   template <typename T>
   static std::string Print(const T& message)
   {

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -17,7 +17,8 @@ namespace
 {
 namespace test
 {
-struct DummyType {
+struct DummyType
+{
   int32_t value = 0;
 };
 }  // namespace test

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -12,10 +12,31 @@
 
 #include <gtest/gtest.h>
 
+namespace
+{
+namespace test
+{
+struct DummyType {
+  int value;
+};
+}  // namespace test
+
+std::ostream& operator<<(
+    std::ostream& os, const test::DummyType& dummy)
+{
+  return os << dummy.value;
+}
+}  // namespace
+
 namespace common_robotics_utilities
 {
 namespace print_test
 {
+GTEST_TEST(PrintTest, CanPrintIfStreamOperatorIsInOuterNamespace)
+{
+  (void)print::Print(std::vector<test::DummyType>());
+}
+
 GTEST_TEST(PrintTest, CanPrintROSMessages)
 {
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -34,7 +34,7 @@ namespace print_test
 {
 GTEST_TEST(PrintTest, CanPrintIfStreamOperatorIsInOuterNamespace)
 {
-  (void)print::Print(std::vector<test::DummyType>());
+  EXPECT_FALSE(print::Print(std::vector<test::DummyType>(3)).empty());
 }
 
 GTEST_TEST(PrintTest, CanPrintROSMessages)
@@ -44,7 +44,7 @@ GTEST_TEST(PrintTest, CanPrintROSMessages)
 #elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
   using Point = geometry_msgs::Point;
 #endif
-  (void)print::Print(std::vector<Point>());
+  EXPECT_FALSE(print::Print(std::vector<Point>(3)).empty());
 }
 }  // namespace print_test
 }  // namespace common_robotics_utilities

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include <common_robotics_utilities/print.hpp>
+#include <common_robotics_utilities/voxel_grid.hpp>
 
 #include <gtest/gtest.h>
 
@@ -17,7 +18,7 @@ namespace
 namespace test
 {
 struct DummyType {
-  int value;
+  int32_t value = 0;
 };
 }  // namespace test
 
@@ -32,9 +33,10 @@ namespace common_robotics_utilities
 {
 namespace print_test
 {
-GTEST_TEST(PrintTest, CanPrintIfStreamOperatorIsInOuterNamespace)
+GTEST_TEST(PrintTest, CanPrintIfADLCanFindStreamOperator)
 {
-  EXPECT_FALSE(print::Print(std::vector<test::DummyType>(3)).empty());
+  std::cout << print::Print(std::vector<voxel_grid::GridIndex>{{1, 1, 1}}) << std::endl;
+  std::cout << print::Print(std::vector<test::DummyType>(3)) << std::endl;
 }
 
 GTEST_TEST(PrintTest, CanPrintROSMessages)
@@ -44,7 +46,7 @@ GTEST_TEST(PrintTest, CanPrintROSMessages)
 #elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
   using Point = geometry_msgs::Point;
 #endif
-  EXPECT_FALSE(print::Print(std::vector<Point>(3)).empty());
+  std::cout << print::Print(std::vector<Point>(3)) << std::endl;
 }
 }  // namespace print_test
 }  // namespace common_robotics_utilities

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -1,0 +1,35 @@
+#include <vector>
+
+#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+#include <geometry_msgs/msg/point.hpp>
+#elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
+#include <geometry_msgs/Point.h>
+#else
+#error "Undefined or unknown COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION"
+#endif
+
+#include <common_robotics_utilities/print.hpp>
+
+#include <gtest/gtest.h>
+
+namespace common_robotics_utilities
+{
+namespace print_test
+{
+GTEST_TEST(PrintTest, CanPrintROSMessages)
+{
+#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+  using Point = geometry_msgs::msg::Point;
+#elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
+  using Point = geometry_msgs::Point;
+#endif
+  (void)print::Print(std::vector<Point>());
+}
+}  // namespace print_test
+}  // namespace common_robotics_utilities
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
ROS 2 interfaces in C++ do not overload the stream operator. This patch provides a generic one based on the `rosidl_generator_traits::to_yaml()` function, and private to the `print::Print()` functionality.