### PR TITLE
Use flow style YAML to print ROS 2 interfaces

### DIFF
--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -33,7 +33,8 @@ struct ROSMessagePrinter
   template <typename T>
   static std::string Print(const T& message)
   {
-    return to_yaml(message);
+    constexpr bool use_flow_style = true;
+    return to_yaml(message, use_flow_style);
   }
 };
 #endif


### PR DESCRIPTION
Precisely what the title says. Follow up after #14. Needs `rosidl` 2.5.0 (including [ros2/rosidl#613](https://github.com/ros2/rosidl/pull/613)).