### PR TITLE
Export Eigen3 dependency manually.

### DIFF
--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -149,6 +149,4 @@ ament_export_dependencies(rclcpp)
 ament_export_dependencies(geometry_msgs)
 ament_export_dependencies(visualization_msgs)
 
-ament_export_dependencies(Eigen3)
-
-ament_package()
+ament_package(CONFIG_EXTRAS cmake/common_robotics_utilities-dependencies.cmake)

--- a/cmake/common_robotics_utilities-dependencies.cmake
+++ b/cmake/common_robotics_utilities-dependencies.cmake
@@ -1,0 +1,3 @@
+find_package(Eigen3 REQUIRED)
+set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+include_directories(SYSTEM ${Eigen3_INCLUDE_DIRS})


### PR DESCRIPTION
Follow up after #6. Eigen3 is too special for `ament_export_dependencies` to do the right thing. 

This patch exports the dependency manually. 