### PR TITLE
Switch RRT and path processing to use uniform unit draw rather than RNG + distributions

### DIFF
--- a/include/common_robotics_utilities/utility.hpp
+++ b/include/common_robotics_utilities/utility.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdlib>
+#include <functional>
 #include <string>
 #include <map>
 #include <set>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <iostream>
@@ -85,6 +87,46 @@ namespace common_robotics_utilities
 {
 namespace utility
 {
+/// Signature for function that returns a double uniformly sampled from
+/// the interval [0.0, 1.0).
+using UniformUnitRealFunction = std::function<double(void)>;
+
+/// Given a UniformUnitRealFunction @param uniform_unit_real_fn, returns an
+/// index in [0, container_size - 1].
+template<typename SizeType>
+SizeType GetUniformRandomIndex(
+    const UniformUnitRealFunction& uniform_unit_real_fn,
+    const SizeType container_size)
+{
+  static_assert(
+      std::is_integral<SizeType>::value, "SizeType must be an integral type");
+  if (container_size < 1)
+  {
+    throw std::invalid_argument("container_size must be >= 1");
+  }
+  return static_cast<SizeType>(std::floor(
+      uniform_unit_real_fn() * static_cast<double>(container_size)));
+}
+
+/// Given a UniformUnitRealFunction @param uniform_unit_real_fn, returns an
+/// index in [start, end].
+template<typename SizeType>
+SizeType GetUniformRandomInRange(
+    const UniformUnitRealFunction& uniform_unit_real_fn,
+    const SizeType start, const SizeType end)
+{
+  static_assert(
+      std::is_integral<SizeType>::value, "SizeType must be an integral type");
+  if (start > end)
+  {
+    throw std::invalid_argument("start must be <= end");
+  }
+  const SizeType range = end - start;
+  const SizeType offset =
+      GetUniformRandomIndex<SizeType>(uniform_unit_real_fn, range + 1);
+  return start + offset;
+}
+
 template <typename T>
 inline T ClampValue(const T& val, const T& min, const T& max)
 {

--- a/include/common_robotics_utilities/utility.hpp
+++ b/include/common_robotics_utilities/utility.hpp
@@ -108,15 +108,13 @@ SizeType GetUniformRandomIndex(
       uniform_unit_real_fn() * static_cast<double>(container_size)));
 }
 
-/// Given a UniformUnitRealFunction @param uniform_unit_real_fn, returns an
-/// index in [start, end].
+/// Given a UniformUnitRealFunction @param uniform_unit_real_fn, returns a
+/// value in [start, end].
 template<typename SizeType>
 SizeType GetUniformRandomInRange(
     const UniformUnitRealFunction& uniform_unit_real_fn,
     const SizeType start, const SizeType end)
 {
-  static_assert(
-      std::is_integral<SizeType>::value, "SizeType must be an integral type");
   if (start > end)
   {
     throw std::invalid_argument("start must be <= end");


### PR DESCRIPTION
Current use in RRT and path processing creates multiple `uniform_real_distribution<double>` and `uniform_int_distribution<size_type>` and passes them and associated RNG type to generate random samples.

This PR factors these uses out to only require a uniform unit real function, i.e. a function that returns a double in [0.0, 1.0). Note that while this approach may be problematic in some cases - see [Notes](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution) - it has been tested to be OK with
```
#include <cstdint>
#include <functional>
#include <iostream>
#include <random>

using UniformUnitRealFunction = std::function<double(void)>;

int64_t GetUniformRandomIndex(
    const UniformUnitRealFunction& uniform_unit_real_fn,
    const int64_t max_index)
{
  return static_cast<int64_t>(std::floor(
      uniform_unit_real_fn() * static_cast<double>(max_index)));
}

int main(int argc, char** argv)
{
  std::mt19937_64 rng(42);
  std::uniform_real_distribution<double> uniform_unit_real_dist(0.0, 1.0);

  UniformUnitRealFunction uniform_unit_real_fn = [&] ()
  {
    return uniform_unit_real_dist(rng);
  };

  const int64_t num_samples = 1000000000;

  for (int64_t sample_num = 0; sample_num < num_samples; sample_num++)
  {
    for (int64_t container_size : {10, 100, 1000, 1000000, 1000000000})
    {
      const int64_t random_index =
          GetUniformRandomIndex(uniform_unit_real_fn, container_size);
      if (random_index == container_size)
      {
        std::cout << "Random draw produced invalid index" << std::endl;
      }
    }
  }
  return 0;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/35)
<!-- Reviewable:end -->
