### PR TITLE
Clang -Wconversion support

### DIFF
--- a/CMakeLists.txt.ros1
+++ b/CMakeLists.txt.ros1
@@ -42,6 +42,9 @@ include_directories(include SYSTEM ${catkin_INCLUDE_DIRS}
                                    ${Eigen3_INCLUDE_DIRS})
 
 ## Build options
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+cmake_policy(SET CMP0069 NEW)
+
 add_compile_options(-std=c++11)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
@@ -50,10 +53,10 @@ add_compile_options(-Wconversion)
 add_compile_options(-Wshadow)
 add_compile_options(-O3)
 add_compile_options(-g)
-add_compile_options(-flto)
 add_compile_options(-Werror=non-virtual-dtor)
 add_compile_options(-Wold-style-cast)
-add_compile_options(-Wmaybe-uninitialized)
+add_compile_options(-Wpessimizing-move)
+add_compile_options(-Wuninitialized)
 
 if(drake_FOUND)
     message(STATUS "Drake found, disabling -march=native")

--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -24,6 +24,9 @@ find_package(drake QUIET)
 include_directories(include SYSTEM ${Eigen3_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 
 ## Build options
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+cmake_policy(SET CMP0069 NEW)
+
 add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
@@ -32,10 +35,10 @@ add_compile_options(-Wconversion)
 add_compile_options(-Wshadow)
 add_compile_options(-O3)
 add_compile_options(-g)
-add_compile_options(-flto)
 add_compile_options(-Werror=non-virtual-dtor)
 add_compile_options(-Wold-style-cast)
-add_compile_options(-Wmaybe-uninitialized)
+add_compile_options(-Wpessimizing-move)
+add_compile_options(-Wuninitialized)
 
 if(drake_FOUND)
     message(STATUS "Drake found, disabling -march=native")

--- a/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
+++ b/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
@@ -215,7 +215,7 @@ private:
     {
       // Note: do not refactor to use .at(), since not all vector-like
       // implementations implement it (ex thrust::host_vector<T>).
-      return data_[data_index];
+      return data_[static_cast<typename BackingStore::size_type>(data_index)];
     }
     else
     {
@@ -229,7 +229,7 @@ private:
     {
       // Note: do not refactor to use .at(), since not all vector-like
       // implementations implement it (ex thrust::host_vector<T>).
-      return data_[data_index];
+      return data_[static_cast<typename BackingStore::size_type>(data_index)];
     }
     else
     {
@@ -240,7 +240,8 @@ private:
   void SetCellFilledContents(const T& value)
   {
     data_.clear();
-    data_.resize(sizes_.TotalCells(), value);
+    data_.resize(static_cast<typename BackingStore::size_type>(
+        sizes_.TotalCells()), value);
     fill_status_ = DSHVGFillStatus::CELL_FILLED;
   }
 

--- a/include/common_robotics_utilities/maybe.hpp
+++ b/include/common_robotics_utilities/maybe.hpp
@@ -15,7 +15,7 @@ template<typename A, typename B>
 struct TaggedUnion
 {
 private:
-  void ConstructFrom(const TaggedUnion<A, B>& other)
+  void ConstructCopy(const TaggedUnion<A, B>& other)
   {
     switch (other.type_)
     {
@@ -34,7 +34,7 @@ private:
     }
   }
 
-  void ConstructFrom(TaggedUnion<A, B>&& other)
+  void ConstructMove(TaggedUnion<A, B>&& other)
   {
     switch (other.type_)
     {
@@ -77,7 +77,7 @@ public:
     B value_b_;
   };
 
-  enum {TYPE_A, TYPE_B} type_;
+  enum {TYPE_A, TYPE_B} type_{};
 
   explicit TaggedUnion(const A& value_a)
       : value_a_(value_a), type_(TYPE_A) {}
@@ -91,9 +91,9 @@ public:
   explicit TaggedUnion(B&& value_b)
       : value_b_(std::move(value_b)), type_(TYPE_B) {}
 
-  TaggedUnion(const TaggedUnion<A, B>& other) { ConstructFrom(other); }
+  TaggedUnion(const TaggedUnion<A, B>& other) { ConstructCopy(other); }
 
-  TaggedUnion(TaggedUnion<A, B>&& other) { ConstructFrom(std::move(other)); }
+  TaggedUnion(TaggedUnion<A, B>&& other) { ConstructMove(std::move(other)); }
 
   ~TaggedUnion() { Cleanup(); }
 
@@ -103,7 +103,7 @@ public:
     {
       Cleanup();
 
-      ConstructFrom(other);
+      ConstructCopy(other);
     }
     return *this;
   }
@@ -114,7 +114,7 @@ public:
     {
       Cleanup();
 
-      ConstructFrom(std::move(other));
+      ConstructMove(std::move(other));
     }
     return *this;
   }

--- a/include/common_robotics_utilities/path_processing.hpp
+++ b/include/common_robotics_utilities/path_processing.hpp
@@ -146,37 +146,39 @@ inline Container AttemptShortcut(
       Container shortcut;
       if (first_half_shortcut.size() > 0 && second_half_shortcut.size() > 0)
       {
-        shortcut.insert(shortcut.end(),
-                        first_half_shortcut.begin(),
-                        first_half_shortcut.end());
+        shortcut.insert(
+            shortcut.end(), first_half_shortcut.begin(),
+            first_half_shortcut.end());
         // Skip the first configuration, since this is a duplicate of the last
         // configuration in the first half shortcut
-        shortcut.insert(shortcut.end(),
-                        second_half_shortcut.begin() + 1,
-                        second_half_shortcut.end());
+        shortcut.insert(
+            shortcut.end(), second_half_shortcut.begin() + 1,
+            second_half_shortcut.end());
       }
       else if (first_half_shortcut.size() > 0)
       {
-        shortcut.insert(shortcut.end(),
-                        first_half_shortcut.begin(),
-                        first_half_shortcut.end());
+        shortcut.insert(
+            shortcut.end(), first_half_shortcut.begin(),
+            first_half_shortcut.end());
         // Skip the middle configuration, since this is a duplicate of the
         // last configuration in the first half shortcut, but include the end
         // index
-        shortcut.insert(shortcut.end(),
-                        current_path.begin() + middle_index + 1,
-                        current_path.begin() + end_index + 1);
+        shortcut.insert(
+            shortcut.end(),
+            current_path.begin() + static_cast<ptrdiff_t>(middle_index) + 1,
+            current_path.begin() + static_cast<ptrdiff_t>(end_index) + 1);
       }
       else if (second_half_shortcut.size() > 0)
       {
         // Skip the middle configuration, since this is a duplicate of the
         // first configuration in the second half shortcut
-        shortcut.insert(shortcut.end(),
-                        current_path.begin() + start_index,
-                        current_path.begin() + middle_index);
-        shortcut.insert(shortcut.end(),
-                        second_half_shortcut.begin(),
-                        second_half_shortcut.end());
+        shortcut.insert(
+            shortcut.end(),
+            current_path.begin() + static_cast<ptrdiff_t>(start_index),
+            current_path.begin() + static_cast<ptrdiff_t>(middle_index));
+        shortcut.insert(
+            shortcut.end(), second_half_shortcut.begin(),
+            second_half_shortcut.end());
       }
       return shortcut;
     }
@@ -251,20 +253,20 @@ inline Container ShortcutSmoothPath(
       if (start_index > 0)
       {
         // Copy the path before the shortcut (excluding start_index)
-        shortened_path.insert(shortened_path.end(),
-                              current_path.begin(),
-                              current_path.begin() + start_index);
+        shortened_path.insert(
+            shortened_path.end(), current_path.begin(),
+            current_path.begin() + static_cast<ptrdiff_t>(start_index));
       }
       // Copy the shortcut
-      shortened_path.insert(shortened_path.end(),
-                            shortcut.begin(),
-                            shortcut.end());
+      shortened_path.insert(
+          shortened_path.end(), shortcut.begin(), shortcut.end());
       if (end_index < current_path.size() - 1)
       {
         // Copy the path after the shortcut (excluding end_index)
-        shortened_path.insert(shortened_path.end(),
-                              current_path.begin() + end_index + 1,
-                              current_path.end());
+        shortened_path.insert(
+            shortened_path.end(),
+            current_path.begin() + static_cast<ptrdiff_t>(end_index) + 1,
+            current_path.end());
       }
       // Swap in as the new current path
       current_path = shortened_path;

--- a/include/common_robotics_utilities/serialization.hpp
+++ b/include/common_robotics_utilities/serialization.hpp
@@ -441,7 +441,8 @@ inline uint64_t SerializeMemcpyableVectorLike(
   const uint64_t size = static_cast<uint64_t>(vec_to_serialize.size());
   SerializeMemcpyable<uint64_t>(size, buffer);
   // Expand the buffer to handle everything
-  const size_t serialized_length = sizeof(T) * vec_to_serialize.size();
+  const size_t serialized_length =
+      sizeof(T) * static_cast<size_t>(vec_to_serialize.size());
   const size_t previous_buffer_size = buffer.size();
   buffer.resize(previous_buffer_size + serialized_length, 0x00);
   // Serialize the contained items

--- a/include/common_robotics_utilities/simple_astar_search.hpp
+++ b/include/common_robotics_utilities/simple_astar_search.hpp
@@ -242,7 +242,7 @@ inline AstarResult<T, Container> PerformAstarSearch(
   int64_t best_start_meeting_goal_index = -1;
   double best_start_meeting_goal_cost = std::numeric_limits<double>::infinity();
 
-  for (int64_t idx = 0; idx < static_cast<int64_t>(start_states.size()); idx++)
+  for (size_t idx = 0; idx < start_states.size(); idx++)
   {
     const T& start_state = start_states.at(idx).State();
     const double start_cost = start_states.at(idx).Cost();
@@ -250,7 +250,7 @@ inline AstarResult<T, Container> PerformAstarSearch(
     {
       if (start_cost < best_start_meeting_goal_cost)
       {
-        best_start_meeting_goal_index = idx;
+        best_start_meeting_goal_index = static_cast<int64_t>(idx);
         best_start_meeting_goal_cost = start_cost;
       }
     }
@@ -260,7 +260,7 @@ inline AstarResult<T, Container> PerformAstarSearch(
   if (best_start_meeting_goal_index >= 0)
   {
     const auto& best_start_meeting_goal =
-        start_states.at(best_start_meeting_goal_index);
+        start_states.at(static_cast<size_t>(best_start_meeting_goal_index));
 
     Container solution;
     solution.push_back(best_start_meeting_goal.State());

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -347,11 +347,11 @@ public:
     std::sort(vector_nodes_to_prune.begin(), vector_nodes_to_prune.end());
     // Make the pruned graph, initialized with the number of nodes we expect it
     // to contain.
-    GraphType pruned_graph(graph.Size() - nodes_to_prune.size());
+    GraphType pruned_graph(
+        graph.Size() - static_cast<int64_t>(nodes_to_prune.size()));
+
     // First, serial pass through to copy nodes to be kept
-    for (int64_t node_index = 0;
-         node_index < static_cast<int64_t>(graph.Size());
-         node_index++)
+    for (int64_t node_index = 0; node_index < graph.Size(); node_index++)
     {
       if (nodes_to_prune.count(node_index) == 0)
       {
@@ -360,8 +360,13 @@ public:
       }
     }
     pruned_graph.ShrinkToFit();
-    // Loop body for second pass to update edges for the kept nodes
-    const auto update_edge_fn = [&] (const int64_t kept_node_index)
+
+    // Second, optionally parallel pass to update edges for the kept nodes
+#if defined(_OPENMP)
+#pragma omp parallel for if (use_parallel)
+#endif
+    for (int64_t kept_node_index = 0; kept_node_index < pruned_graph.Size();
+         kept_node_index++)
     {
       GraphNodeType& kept_graph_node
           = pruned_graph.GetNodeMutable(kept_node_index);
@@ -449,28 +454,7 @@ public:
       kept_graph_node.SetInEdges(new_in_edges);
       kept_graph_node.SetOutEdges(new_out_edges);
     };
-    // Second, optionally parallel pass to update edges for the kept nodes
-    if (use_parallel)
-    {
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
-      for (int64_t kept_node_index = 0;
-          kept_node_index < static_cast<int64_t>(pruned_graph.Size());
-          kept_node_index++)
-      {
-        update_edge_fn(kept_node_index);
-      }
-    }
-    else
-    {
-      for (int64_t kept_node_index = 0;
-          kept_node_index < static_cast<int64_t>(pruned_graph.Size());
-          kept_node_index++)
-      {
-        update_edge_fn(kept_node_index);
-      }
-    }
+
     return pruned_graph;
   }
 
@@ -486,7 +470,10 @@ public:
     }
   }
 
-  Graph(const size_t expected_size) { nodes_.reserve(expected_size); }
+  Graph(const int64_t expected_size)
+  {
+    nodes_.reserve(static_cast<int64_t>(expected_size));
+  }
 
   Graph() {}
 
@@ -562,11 +549,11 @@ public:
     nodes_.shrink_to_fit();
   }
 
-  size_t Size() const { return nodes_.size(); }
+  int64_t Size() const { return static_cast<int64_t>(nodes_.size()); }
 
   bool IndexInRange(const int64_t index) const
   {
-    if ((index >= 0) && (index < static_cast<int64_t>(nodes_.size())))
+    if ((index >= 0) && (index < Size()))
     {
       return true;
     }

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -472,7 +472,7 @@ public:
 
   Graph(const int64_t expected_size)
   {
-    nodes_.reserve(static_cast<int64_t>(expected_size));
+    nodes_.reserve(static_cast<size_t>(expected_size));
   }
 
   Graph() {}

--- a/include/common_robotics_utilities/simple_graph_search.hpp
+++ b/include/common_robotics_utilities/simple_graph_search.hpp
@@ -99,7 +99,10 @@ public:
     return bytes_read;
   }
 
-  size_t Size() const { return previous_index_map_.size(); }
+  int64_t Size() const
+  {
+    return static_cast<int64_t>(previous_index_map_.size());
+  }
 
   int64_t GetPreviousIndex(const int64_t node_index) const
   {

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -70,18 +70,20 @@ inline Container ComputeClusterCentersWeighted(
     // TODO: improve this to avoid copies. It's possible right now, but it would
     // result in the average functions being more complicated and slower.
     // Separate the datapoints into their clusters
-    std::vector<Container> clustered_data(num_clusters);
-    std::vector<std::vector<double>> clustered_data_weights(num_clusters);
+    std::vector<Container> clustered_data(static_cast<size_t>(num_clusters));
+    std::vector<std::vector<double>> clustered_data_weights(
+        static_cast<size_t>(num_clusters));
     for (size_t idx = 0; idx < data.size(); idx++)
     {
       const DataType& datapoint = data[idx];
       const int32_t label = cluster_labels.at(idx);
-      clustered_data.at(label).push_back(datapoint);
-      clustered_data_weights.at(label).push_back(data_weights.at(idx));
+      clustered_data.at(static_cast<size_t>(label)).push_back(datapoint);
+      clustered_data_weights.at(
+          static_cast<size_t>(label)).push_back(data_weights.at(idx));
     }
 
     // Compute the center of each cluster
-    Container cluster_centers(num_clusters);
+    Container cluster_centers(static_cast<size_t>(num_clusters));
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
@@ -181,7 +183,8 @@ inline std::vector<int32_t> ClusterWeighted(
     }
   }
   // Prepare an RNG for cluster initialization
-  std::mt19937_64 prng(prng_seed);
+  std::mt19937_64 prng(
+      static_cast<typename std::mt19937_64::result_type>(prng_seed));
   std::uniform_int_distribution<size_t> initialization_distribution(
       0, data.size() - 1);
   // Initialize cluster centers
@@ -235,7 +238,7 @@ inline std::vector<int32_t> ClusterWeighted(
       const size_t random_index = initialization_distribution(prng);
       index_map[random_index] = 1u;
     }
-    cluster_centers.reserve(num_clusters);
+    cluster_centers.reserve(static_cast<size_t>(num_clusters));
     for (auto itr = index_map.begin(); itr != index_map.end(); ++itr)
     {
       if (itr->second == 1u)

--- a/include/common_robotics_utilities/simple_knearest_neighbors.hpp
+++ b/include/common_robotics_utilities/simple_knearest_neighbors.hpp
@@ -75,7 +75,8 @@ inline std::vector<IndexAndDistance> GetKNearestNeighborsParallel(
   if (items.size() > K)
   {
     std::vector<std::vector<IndexAndDistance>> per_thread_nearests(
-        openmp_helpers::GetNumOmpThreads(), std::vector<IndexAndDistance>(K));
+        static_cast<size_t>(openmp_helpers::GetNumOmpThreads()),
+        std::vector<IndexAndDistance>(K));
 #if defined(_OPENMP)
 #pragma omp parallel for
 #endif
@@ -83,7 +84,8 @@ inline std::vector<IndexAndDistance> GetKNearestNeighborsParallel(
     {
       const Item& item = items[idx];
       const double distance = distance_fn(item, current);
-      const auto thread_num = openmp_helpers::GetContextOmpThreadNum();
+      const size_t thread_num =
+          static_cast<size_t>(openmp_helpers::GetContextOmpThreadNum());
       std::vector<IndexAndDistance>& current_thread_nearests =
           per_thread_nearests.at(thread_num);
       auto itr = std::max_element(current_thread_nearests.begin(),

--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -50,9 +50,8 @@ public:
       const serialization::Deserializer<StateType>& value_deserializer)
   {
     SimpleRRTPlannerState<StateType> temp_state;
-    const uint64_t bytes_read
-        = temp_state.DeserializeSelf(buffer, starting_offset,
-                                     value_deserializer);
+    const uint64_t bytes_read = temp_state.DeserializeSelf(
+        buffer, starting_offset, value_deserializer);
     return serialization::MakeDeserialized(temp_state, bytes_read);
   }
 
@@ -184,7 +183,7 @@ template<typename StateType>
 class SimpleRRTPlannerTree
 {
 private:
-   SimpleRRTPlannerStateVector<StateType> nodes_;
+  SimpleRRTPlannerStateVector<StateType> nodes_;
 
 public:
   using NodeType = SimpleRRTPlannerState<StateType>;
@@ -232,7 +231,6 @@ public:
     return serialization::MakeDeserialized(
         tree, deserialized_nodes.BytesRead());
   }
-
 
   SimpleRRTPlannerTree() {}
 

--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -338,7 +338,8 @@ public:
       {
         if (parent_index != static_cast<int64_t>(current_index))
         {
-          const auto& parent_state = nodes.at(parent_index);
+          const auto& parent_state =
+              nodes.at(static_cast<size_t>(parent_index));
           // Make sure the parent state is initialized.
           if (!parent_state.IsInitialized())
           {
@@ -385,7 +386,8 @@ public:
         {
           if (current_child_index > static_cast<int64_t>(current_index))
           {
-            const auto& child_state = nodes.at(current_child_index);
+            const auto& child_state =
+                nodes.at(static_cast<size_t>(current_child_index));
             if (!child_state.IsInitialized())
             {
               std::cerr << "Tree contains uninitialized node(s) "

--- a/include/common_robotics_utilities/simple_task_planner.hpp
+++ b/include/common_robotics_utilities/simple_task_planner.hpp
@@ -302,7 +302,8 @@ TaskStateAStarResult<State> PlanTaskStateSequence(
          index < static_cast<int64_t>(primitive_collection.Primitives().size());
          index++)
     {
-      const auto& primitive = primitive_collection.Primitives().at(index);
+      const auto& primitive =
+          primitive_collection.Primitives().at(static_cast<size_t>(index));
       if (primitive->IsCandidate(current_state))
       {
         const auto outcomes = primitive->GetOutcomes(current_state);
@@ -416,13 +417,11 @@ NextPrimitiveToExecute<State, Container> GetNextPrimitiveToExecute(
     const State& outcome_state = task_sequence.Path().at(0).Outcome();
 
     int64_t best_outcome_index = -1;
-    for (int64_t index = 0;
-         index < static_cast<int64_t>(potential_outcome_states.size());
-         index++)
+    for (size_t index = 0; index < potential_outcome_states.size(); index++)
     {
       if (state_equaler(outcome_state, potential_outcome_states.at(index)))
       {
-        best_outcome_index = index;
+        best_outcome_index = static_cast<int64_t>(index);
         break;
       }
     }
@@ -435,7 +434,7 @@ NextPrimitiveToExecute<State, Container> GetNextPrimitiveToExecute(
     {
       const auto& next_state_and_index = task_sequence.Path().at(1);
       const auto& next_primitive = primitive_collection.Primitives().at(
-          next_state_and_index.PrimitiveIndex());
+          static_cast<size_t>(next_state_and_index.PrimitiveIndex()));
 
       return NextPrimitiveToExecute<State, Container>(
           next_primitive, best_outcome_index);
@@ -490,8 +489,8 @@ Container PerformSingleTaskExecution(
             state_heuristic_fn, state_hasher, state_equaler);
 
     // Get the outcome state and add it to the execution trace.
-    const State& selected_outcome =
-        current_outcomes.at(next_to_execute.SelectedOutcomeIndex());
+    const State& selected_outcome = current_outcomes.at(
+        static_cast<size_t>(next_to_execute.SelectedOutcomeIndex()));
     task_state_trace.push_back(selected_outcome);
 
     // Call the user-provided callback.

--- a/include/common_robotics_utilities/voxel_grid.hpp
+++ b/include/common_robotics_utilities/voxel_grid.hpp
@@ -552,7 +552,7 @@ private:
     {
       // Note: do not refactor to use .at(), since not all vector-like
       // implementations implement it (ex thrust::host_vector<T>).
-      return data_[data_index];
+      return data_[static_cast<typename BackingStore::size_type>(data_index)];
     }
     else
     {
@@ -566,7 +566,7 @@ private:
     {
       // Note: do not refactor to use .at(), since not all vector-like
       // implementations implement it (ex thrust::host_vector<T>).
-      return data_[data_index];
+      return data_[static_cast<typename BackingStore::size_type>(data_index)];
     }
     else
     {
@@ -577,7 +577,8 @@ private:
   void SetContents(const T& value)
   {
     data_.clear();
-    data_.resize(sizes_.TotalCells(), value);
+    data_.resize(static_cast<typename BackingStore::size_type>(
+        sizes_.TotalCells()), value);
   }
 
   uint64_t BaseSerializeSelf(

--- a/src/common_robotics_utilities/base64_helpers.cpp
+++ b/src/common_robotics_utilities/base64_helpers.cpp
@@ -18,7 +18,7 @@ static const std::array<int32_t, 256> B64IndexTable =
      25, 0, 0, 0, 0, 63, 0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
      39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
 
-static const std::array<uint8_t, 64> B64ValueTable =
+static const std::array<char, 64> B64ValueTable =
     {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
      'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
      'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
@@ -34,22 +34,24 @@ std::vector<uint8_t> Decode(const std::string& encoded)
   std::vector<uint8_t> buffer(L / 4 * 3 + pad, 0x00);
   for (size_t i = 0, j = 0; i < L; i += 4)
   {
-    const int32_t n = B64IndexTable[encoded[i]] << 18
-                      | B64IndexTable[encoded[i + 1]] << 12
-                      | B64IndexTable[encoded[i + 2]] << 6
-                      | B64IndexTable[encoded[i + 3]];
+    const int32_t n =
+        B64IndexTable[static_cast<size_t>(encoded[i])] << 18
+        | B64IndexTable[static_cast<size_t>(encoded[i + 1])] << 12
+        | B64IndexTable[static_cast<size_t>(encoded[i + 2])] << 6
+        | B64IndexTable[static_cast<size_t>(encoded[i + 3])];
     buffer[j++] = static_cast<uint8_t>(n >> 16);
     buffer[j++] = static_cast<uint8_t>(n >> 8 & 0xFF);
     buffer[j++] = static_cast<uint8_t>(n & 0xFF);
   }
   if (pad > 0)
   {
-    int32_t n = B64IndexTable[encoded[L]] << 18
-                | B64IndexTable[encoded[L + 1]] << 12;
+    int32_t n =
+        B64IndexTable[static_cast<size_t>(encoded[L])] << 18
+        | B64IndexTable[static_cast<size_t>(encoded[L + 1])] << 12;
     buffer[buffer.size() - 1] = static_cast<uint8_t>(n >> 16);
     if (encoded_length > L + 2 && encoded[L + 2] != '=')
     {
-      n |= B64IndexTable[encoded[L + 2]] << 6;
+      n |= B64IndexTable[static_cast<size_t>(encoded[L + 2])] << 6;
       buffer.push_back(static_cast<uint8_t>(n >> 8 & 0xFF));
     }
   }
@@ -71,35 +73,38 @@ std::string Encode(const std::vector<uint8_t>& binary)
   size_t output_position = 0;
   while (binary_length - input_position >= 3)
   {
-    encoded[output_position++] =
-        B64ValueTable[binary[input_position + 0] >> 2];
-    encoded[output_position++] =
-        B64ValueTable[((binary[input_position + 0] & 0x03) << 4)
-                      | (binary[input_position + 1] >> 4)];
-    encoded[output_position++] =
-        B64ValueTable[((binary[input_position + 1] & 0x0f) << 2)
-                      | (binary[input_position + 2] >> 6)];
-    encoded[output_position++] =
-        B64ValueTable[binary[input_position + 2] & 0x3f];
+    encoded[output_position++] = B64ValueTable[
+        static_cast<size_t>(binary[input_position + 0] >> 2)];
+    encoded[output_position++] = B64ValueTable[
+        static_cast<size_t>(
+            ((binary[input_position + 0] & 0x03) << 4)
+            | (binary[input_position + 1] >> 4))];
+    encoded[output_position++] = B64ValueTable[
+        static_cast<size_t>(
+            ((binary[input_position + 1] & 0x0f) << 2)
+            | (binary[input_position + 2] >> 6))];
+    encoded[output_position++] = B64ValueTable[
+        static_cast<size_t>(binary[input_position + 2] & 0x3f)];
     input_position += 3;
   }
   if (input_position < binary_length)
   {
-    encoded[output_position++] =
-        B64ValueTable[binary[input_position + 0] >> 2];
+    encoded[output_position++] = B64ValueTable[
+        static_cast<size_t>(binary[input_position + 0] >> 2)];
     if ((binary_length - input_position) == 1)
     {
-      encoded[output_position++] =
-          B64ValueTable[(binary[input_position + 0] & 0x03) << 4];
+      encoded[output_position++] = B64ValueTable[
+          static_cast<size_t>((binary[input_position + 0] & 0x03) << 4)];
       encoded[output_position++] = '=';
     }
     else
     {
-      encoded[output_position++] =
-          B64ValueTable[((binary[input_position + 0] & 0x03) << 4)
-                        | (binary[input_position + 1] >> 4)];
-      encoded[output_position++] =
-          B64ValueTable[(binary[input_position + 1] & 0x0f) << 2];
+      encoded[output_position++] = B64ValueTable[
+          static_cast<size_t>(
+              ((binary[input_position + 0] & 0x03) << 4)
+              | (binary[input_position + 1] >> 4))];
+      encoded[output_position++] = B64ValueTable[
+          static_cast<size_t>((binary[input_position + 1] & 0x0f) << 2)];
     }
     encoded[output_position++] = '=';
   }

--- a/src/common_robotics_utilities/serialization.cpp
+++ b/src/common_robotics_utilities/serialization.cpp
@@ -140,7 +140,8 @@ Deserialized<Eigen::MatrixXd> DeserializeMatrixXd(
   {
     throw std::invalid_argument("Not enough room in the provided buffer");
   }
-  Eigen::MatrixXd deserialized = Eigen::MatrixXd::Zero(rows, cols);
+  Eigen::MatrixXd deserialized = Eigen::MatrixXd::Zero(
+      static_cast<ssize_t>(rows), static_cast<ssize_t>(cols));
   memcpy(deserialized.data(), &buffer[current_position], serialized_length);
   current_position += serialized_length;
   // Figure out how many bytes were read

--- a/test/maybe_test.cpp
+++ b/test/maybe_test.cpp
@@ -23,6 +23,17 @@ public:
 
   DefaultConstructibleWrapper(const int32_t value) : value_(value) {}
 
+  DefaultConstructibleWrapper(
+      const DefaultConstructibleWrapper& other) = default;
+
+  DefaultConstructibleWrapper(DefaultConstructibleWrapper&& other) = default;
+
+  DefaultConstructibleWrapper& operator=(
+      const DefaultConstructibleWrapper& other) = default;
+
+  DefaultConstructibleWrapper& operator=(
+      DefaultConstructibleWrapper&& other) = default;
+
   int32_t& Value() { return value_; }
 
   const int32_t& Value() const { return value_; }
@@ -33,7 +44,7 @@ GTEST_TEST(OwningMaybeTest, DefaultConstructMoveAndAssign)
   // Test basic construction.
   const OwningMaybe<DefaultConstructibleWrapper> maybe_not;
   OwningMaybe<DefaultConstructibleWrapper> maybe_default(
-      std::move(DefaultConstructibleWrapper()));
+      DefaultConstructibleWrapper{});
   const OwningMaybe<DefaultConstructibleWrapper> maybe_1(
       DefaultConstructibleWrapper(1));
 
@@ -52,8 +63,8 @@ GTEST_TEST(OwningMaybeTest, DefaultConstructMoveAndAssign)
   // Test copy and move constructors.
   const OwningMaybe<DefaultConstructibleWrapper> copy_maybe_1(maybe_1);
   const OwningMaybe<DefaultConstructibleWrapper> copy_temp_maybe(
-      std::move(OwningMaybe<DefaultConstructibleWrapper>(
-          DefaultConstructibleWrapper(2))));
+      OwningMaybe<DefaultConstructibleWrapper>(
+          DefaultConstructibleWrapper(2)));
 
   EXPECT_TRUE(copy_maybe_1);
   EXPECT_TRUE(copy_temp_maybe);
@@ -89,6 +100,18 @@ public:
 
   NonDefaultConstructibleWrapper(const int32_t value) : value_(value) {}
 
+  NonDefaultConstructibleWrapper(
+      const NonDefaultConstructibleWrapper& other) = default;
+
+  NonDefaultConstructibleWrapper(
+      NonDefaultConstructibleWrapper&& other) = default;
+
+  NonDefaultConstructibleWrapper& operator=(
+      const NonDefaultConstructibleWrapper& other) = default;
+
+  NonDefaultConstructibleWrapper& operator=(
+      NonDefaultConstructibleWrapper&& other) = default;
+
   int32_t& Value() { return value_; }
 
   const int32_t& Value() const { return value_; }
@@ -108,8 +131,8 @@ GTEST_TEST(OwningMaybeTest, NoDefaultConstructMoveAndAssign)
   // Test copy and move constructors.
   OwningMaybe<NonDefaultConstructibleWrapper> copy_maybe_1(maybe_1);
   OwningMaybe<NonDefaultConstructibleWrapper> copy_temp_maybe(
-      std::move(OwningMaybe<NonDefaultConstructibleWrapper>(
-          NonDefaultConstructibleWrapper(2))));
+      OwningMaybe<NonDefaultConstructibleWrapper>(
+          NonDefaultConstructibleWrapper(2)));
 
   EXPECT_TRUE(copy_maybe_1);
   EXPECT_TRUE(copy_temp_maybe);
@@ -149,8 +172,8 @@ GTEST_TEST(OwningMaybeTest, ConstNoDefaultConstructMoveAndAssign)
   // Test copy and move constructors.
   const OwningMaybe<const NonDefaultConstructibleWrapper> copy_maybe_1(maybe_1);
   const OwningMaybe<const NonDefaultConstructibleWrapper> copy_temp_maybe(
-      std::move(OwningMaybe<const NonDefaultConstructibleWrapper>(
-          NonDefaultConstructibleWrapper(2))));
+      OwningMaybe<const NonDefaultConstructibleWrapper>(
+          NonDefaultConstructibleWrapper(2)));
 
   EXPECT_TRUE(copy_maybe_1);
   EXPECT_TRUE(copy_temp_maybe);
@@ -181,7 +204,7 @@ GTEST_TEST(OwningMaybeTest, NonTrivialConstructMoveAndAssign)
   // Test basic construction.
   OwningMaybe<std::vector<int32_t>> maybe_not;
   OwningMaybe<std::vector<int32_t>> maybe_default(
-      std::move(std::vector<int32_t>()));
+      std::vector<int32_t>{});
   OwningMaybe<std::vector<int32_t>> maybe_1(
       std::vector<int32_t>(1, 1));
 
@@ -201,8 +224,8 @@ GTEST_TEST(OwningMaybeTest, NonTrivialConstructMoveAndAssign)
   // Test copy and move constructors.
   OwningMaybe<std::vector<int32_t>> copy_maybe_1(maybe_1);
   OwningMaybe<std::vector<int32_t>> copy_temp_maybe(
-      std::move(OwningMaybe<std::vector<int32_t>>(
-          std::vector<int32_t>(2, 2))));
+      OwningMaybe<std::vector<int32_t>>(
+          std::vector<int32_t>(2, 2)));
 
   EXPECT_TRUE(copy_maybe_1);
   EXPECT_TRUE(copy_temp_maybe);
@@ -279,8 +302,7 @@ GTEST_TEST(ReferencingMaybeTest, ConstructMoveAndAssign)
 
   // Test copy and move constructors.
   ReferencingMaybe<int32_t> copy_maybe(maybe_1);
-  ReferencingMaybe<int32_t> copy_temp_maybe(
-      std::move(ReferencingMaybe<int32_t>(value_2)));
+  ReferencingMaybe<int32_t> copy_temp_maybe(ReferencingMaybe<int32_t>{value_2});
 
   EXPECT_EQ(copy_maybe.Value(), value_1);
   EXPECT_EQ(copy_temp_maybe.Value(), value_2);

--- a/test/planning_test.cpp
+++ b/test/planning_test.cpp
@@ -467,11 +467,10 @@ GTEST_TEST(PlanningTest, Test)
             << "New roadmap nodes: " << loaded_roadmap.Size() << "\n"
             << "New roadmap binary size: " << load_buffer.size() << std::endl;
 
-  for (size_t idx = 0; idx < loaded_roadmap.Size(); idx++)
+  for (int64_t idx = 0; idx < loaded_roadmap.Size(); idx++)
   {
-    const auto& old_node = roadmap.GetNodeImmutable(static_cast<int64_t>(idx));
-    const auto& new_node
-        = loaded_roadmap.GetNodeImmutable(static_cast<int64_t>(idx));
+    const auto& old_node = roadmap.GetNodeImmutable(idx);
+    const auto& new_node = loaded_roadmap.GetNodeImmutable(idx);
     const Waypoint& old_waypoint = old_node.GetValueImmutable();
     const Waypoint& new_waypoint = new_node.GetValueImmutable();
     ASSERT_EQ(old_waypoint.first, new_waypoint.first);

--- a/test/voxel_grid_test.cpp
+++ b/test/voxel_grid_test.cpp
@@ -37,7 +37,7 @@ GTEST_TEST(VoxelGridTest, IndexLookup)
       = voxel_grid::VoxelGrid<int32_t>::Deserialize(
           buffer, 0, serialization::DeserializeMemcpyable<int32_t>).Value();
   // Check the values
-  int32_t check_index = 0;
+  size_t check_index = 0;
   for (int64_t x_index = 0; x_index < read_grid.GetNumXCells(); x_index++)
   {
     for (int64_t y_index = 0; y_index < read_grid.GetNumYCells(); y_index++)
@@ -88,7 +88,7 @@ GTEST_TEST(VoxelGridTest, LocationLookup)
       = voxel_grid::VoxelGrid<int32_t>::Deserialize(
           buffer, 0, serialization::DeserializeMemcpyable<int32_t>).Value();
   // Check the values
-  int32_t check_index = 0;
+  size_t check_index = 0;
   for (double x_pos = -9.5; x_pos <= 9.5; x_pos += 1.0)
   {
     for (double y_pos = -9.5; y_pos <= 9.5; y_pos += 1.0)
@@ -160,7 +160,7 @@ GTEST_TEST(VoxelGridTest, DshvgLookup)
       = voxel_grid::DynamicSpatialHashedVoxelGrid<int32_t>::Deserialize(
           buffer, 0, serialization::DeserializeMemcpyable<int32_t>).Value();
   // Check the values
-  int32_t check_index = 0;
+  size_t check_index = 0;
   for (double x_pos = -9.5; x_pos <= 9.5; x_pos += 1.0)
   {
     for (double y_pos = -9.5; y_pos <= 9.5; y_pos += 1.0)


### PR DESCRIPTION
Fixes all issues turned up by Clang `-Wconversion` as well as a few other items:
- Replacement of manual parallel/serial OpenMP branches with `#pragma omp parallel for if(use_parallel)` clauses
- Replacement of remaining unsigned container sizes with signed container sizes (`Graph<T>` and friends)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/46)
<!-- Reviewable:end -->
