### PR TITLE
Restructure graph search methods

### DIFF
--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -145,12 +146,15 @@ public:
 template<typename NodeValueType>
 class GraphNode
 {
+public:
+  using EdgeType = GraphEdge;
+
 private:
   using GraphNodeType = GraphNode<NodeValueType>;
 
   NodeValueType value_;
-  std::vector<GraphEdge> in_edges_;
-  std::vector<GraphEdge> out_edges_;
+  std::vector<EdgeType> in_edges_;
+  std::vector<EdgeType> out_edges_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -174,8 +178,8 @@ public:
   }
 
   GraphNode(const NodeValueType& value,
-            const std::vector<GraphEdge>& new_in_edges,
-            const std::vector<GraphEdge>& new_out_edges)
+            const std::vector<EdgeType>& new_in_edges,
+            const std::vector<EdgeType>& new_out_edges)
       : value_(value), in_edges_(new_in_edges), out_edges_(new_out_edges) {}
 
   explicit GraphNode(const NodeValueType& value) : value_(value) {}
@@ -190,11 +194,11 @@ public:
     // Serialize the value
     value_serializer(value_, buffer);
     // Serialize the in edges
-    serialization::SerializeVectorLike<GraphEdge>(
-        in_edges_, buffer, GraphEdge::Serialize);
+    serialization::SerializeVectorLike<EdgeType>(
+        in_edges_, buffer, EdgeType::Serialize);
     // Serialize the out edges
-    serialization::SerializeVectorLike<GraphEdge>(
-        out_edges_, buffer, GraphEdge::Serialize);
+    serialization::SerializeVectorLike<EdgeType>(
+        out_edges_, buffer, EdgeType::Serialize);
     // Figure out how many bytes were written
     const uint64_t end_buffer_size = buffer.size();
     const uint64_t bytes_written = end_buffer_size - start_buffer_size;
@@ -213,14 +217,14 @@ public:
     current_position += value_deserialized.BytesRead();
     // Deserialize the in edges
     const auto in_edges_deserialized
-        = serialization::DeserializeVectorLike<GraphEdge>(
-            buffer, current_position, GraphEdge::Deserialize);
+        = serialization::DeserializeVectorLike<EdgeType>(
+            buffer, current_position, EdgeType::Deserialize);
     in_edges_ = in_edges_deserialized.Value();
     current_position += in_edges_deserialized.BytesRead();
     // Deserialize the out edges
     const auto out_edges_deserialized
-        = serialization::DeserializeVectorLike<GraphEdge>(
-            buffer, current_position, GraphEdge::Deserialize);
+        = serialization::DeserializeVectorLike<EdgeType>(
+            buffer, current_position, EdgeType::Deserialize);
     out_edges_ = out_edges_deserialized.Value();
     current_position += out_edges_deserialized.BytesRead();
     // Figure out how many bytes were read
@@ -257,48 +261,39 @@ public:
 
   NodeValueType& GetValueMutable() { return value_; }
 
-  void AddInEdge(const GraphEdge& new_in_edge)
+  void AddInEdge(const EdgeType& new_in_edge)
   {
     in_edges_.push_back(new_in_edge);
   }
 
-  void AddOutEdge(const GraphEdge& new_out_edge)
+  void AddOutEdge(const EdgeType& new_out_edge)
   {
     out_edges_.push_back(new_out_edge);
   }
 
-  void AddEdgePair(const GraphEdge& new_in_edge, const GraphEdge& new_out_edge)
+  void AddEdgePair(const EdgeType& new_in_edge, const EdgeType& new_out_edge)
   {
     AddInEdge(new_in_edge);
     AddOutEdge(new_out_edge);
   }
 
-  const std::vector<GraphEdge>& GetInEdgesImmutable() const
-  {
-    return in_edges_;
-  }
+  const std::vector<EdgeType>& GetInEdgesImmutable() const { return in_edges_; }
 
-  std::vector<GraphEdge>& GetInEdgesMutable()
-  {
-    return in_edges_;
-  }
+  std::vector<EdgeType>& GetInEdgesMutable() { return in_edges_; }
 
-  const std::vector<GraphEdge>& GetOutEdgesImmutable() const
+  const std::vector<EdgeType>& GetOutEdgesImmutable() const
   {
     return out_edges_;
   }
 
-  std::vector<GraphEdge>& GetOutEdgesMutable()
-  {
-    return out_edges_;
-  }
+  std::vector<EdgeType>& GetOutEdgesMutable() { return out_edges_; }
 
-  void SetInEdges(const std::vector<GraphEdge>& new_in_edges)
+  void SetInEdges(const std::vector<EdgeType>& new_in_edges)
   {
     in_edges_ = new_in_edges;
   }
 
-  void SetOutEdges(const std::vector<GraphEdge>& new_out_edges)
+  void SetOutEdges(const std::vector<EdgeType>& new_out_edges)
   {
     out_edges_ = new_out_edges;
   }
@@ -315,9 +310,8 @@ bool CheckGraphLinkage(const GraphType& graph)
   {
     const auto& current_node = graph.GetNodeImmutable(idx);
     // Check the in edges first
-    const std::vector<GraphEdge>& in_edges
-        = current_node.GetInEdgesImmutable();
-    for (const GraphEdge& current_edge : in_edges)
+    const auto& in_edges = current_node.GetInEdgesImmutable();
+    for (const auto& current_edge : in_edges)
     {
       // Check from index to make sure it's in bounds
       const int64_t from_index = current_edge.GetFromIndex();
@@ -341,12 +335,11 @@ bool CheckGraphLinkage(const GraphType& graph)
       }
       // Check to make sure that the from index node is linked to us
       const auto& from_node = graph.GetNodeImmutable(from_index);
-      const std::vector<GraphEdge>& from_node_out_edges
-          = from_node.GetOutEdgesImmutable();
+      const auto& from_node_out_edges = from_node.GetOutEdgesImmutable();
       bool from_node_connection_valid = false;
       // Make sure at least one out edge of the from index node corresponds
       // to the current node
-      for (const GraphEdge& current_from_node_out_edge : from_node_out_edges)
+      for (const auto& current_from_node_out_edge : from_node_out_edges)
       {
         if (current_from_node_out_edge.GetToIndex() == idx)
         {
@@ -360,9 +353,8 @@ bool CheckGraphLinkage(const GraphType& graph)
       }
     }
     // Check the out edges second
-    const std::vector<GraphEdge>& out_edges
-        = current_node.GetOutEdgesImmutable();
-    for (const GraphEdge& current_edge : out_edges)
+    const auto& out_edges = current_node.GetOutEdgesImmutable();
+    for (const auto& current_edge : out_edges)
     {
       // Check from index to make sure it matches our own index
       const int64_t from_index = current_edge.GetFromIndex();
@@ -386,12 +378,11 @@ bool CheckGraphLinkage(const GraphType& graph)
       }
       // Check to make sure that the to index node is linked to us
       const auto& to_node = graph.GetNodeImmutable(to_index);
-      const std::vector<GraphEdge>& to_node_in_edges
-          = to_node.GetInEdgesImmutable();
+      const auto& to_node_in_edges = to_node.GetInEdgesImmutable();
       bool to_node_connection_valid = false;
       // Make sure at least one in edge of the to index node corresponds to
       // the current node
-      for (const GraphEdge& current_to_node_in_edge : to_node_in_edges)
+      for (const auto& current_to_node_in_edge : to_node_in_edges)
       {
         if (current_to_node_in_edge.GetFromIndex() == idx)
         {
@@ -411,13 +402,16 @@ bool CheckGraphLinkage(const GraphType& graph)
 template<typename NodeValueType>
 class Graph
 {
+public:
+  using NodeType = GraphNode<NodeValueType>;
+  using EdgeType = typename NodeType::EdgeType;
+
 private:
   using GraphType = Graph<NodeValueType>;
-  using GraphNodeType = GraphNode<NodeValueType>;
-  using GraphNodeAllocatorType = GraphNodeAllocator<NodeValueType>;
-  using GraphNodeVector = std::vector<GraphNodeType, GraphNodeAllocatorType>;
+  using NodeAllocatorType = GraphNodeAllocator<NodeValueType>;
+  using NodeVector = std::vector<NodeType, NodeAllocatorType>;
 
-  GraphNodeVector nodes_;
+  NodeVector nodes_;
 
 public:
   static uint64_t Serialize(
@@ -471,10 +465,9 @@ public:
     for (int64_t kept_node_index = 0; kept_node_index < pruned_graph.Size();
          kept_node_index++)
     {
-      GraphNodeType& kept_graph_node
-          = pruned_graph.GetNodeMutable(kept_node_index);
+      NodeType& kept_graph_node = pruned_graph.GetNodeMutable(kept_node_index);
       // Make space for the updated in edges
-      std::vector<GraphEdge> new_in_edges;
+      std::vector<EdgeType> new_in_edges;
       new_in_edges.reserve(kept_graph_node.GetInEdgesImmutable().size());
       // Go through the in edges
       for (const auto& in_edge : kept_graph_node.GetInEdgesImmutable())
@@ -484,7 +477,7 @@ public:
         if (nodes_to_prune.count(original_from_index) == 0)
         {
           // Make a copy of the existing edge
-          GraphEdge new_in_edge = in_edge;
+          EdgeType new_in_edge = in_edge;
           // Update the "to index" to our node's index
           new_in_edge.SetToIndex(kept_node_index);
           // Update the "from index" to account for pruned nodes
@@ -514,7 +507,7 @@ public:
       }
       new_in_edges.shrink_to_fit();
       // Make space for the updated out edges
-      std::vector<GraphEdge> new_out_edges;
+      std::vector<EdgeType> new_out_edges;
       new_out_edges.reserve(kept_graph_node.GetOutEdgesImmutable().size());
       // Go through the out edges
       for (const auto& out_edge : kept_graph_node.GetOutEdgesImmutable())
@@ -524,7 +517,7 @@ public:
         if (nodes_to_prune.count(original_to_index) == 0)
         {
           // Make a copy of the existing edge
-          GraphEdge new_out_edge = out_edge;
+          EdgeType new_out_edge = out_edge;
           // Update the "from index" to our node's index
           new_out_edge.SetFromIndex(kept_node_index);
           // Update the "from index" to account for pruned nodes
@@ -561,7 +554,7 @@ public:
     return pruned_graph;
   }
 
-  Graph(const GraphNodeVector& nodes)
+  Graph(const NodeVector& nodes)
   {
     GraphType temp_graph;
     temp_graph.nodes_ = nodes;
@@ -588,14 +581,12 @@ public:
       const serialization::Serializer<NodeValueType>& value_serializer) const
   {
     const uint64_t start_buffer_size = buffer.size();
-    const serialization::Serializer<GraphNodeType> graph_node_serializer =
-        [&] (const GraphNodeType& node,
-             std::vector<uint8_t>& serialize_buffer)
+    const serialization::Serializer<NodeType> graph_node_serializer =
+        [&] (const NodeType& node, std::vector<uint8_t>& serialize_buffer)
     {
-      return GraphNodeType::Serialize(
-          node, serialize_buffer, value_serializer);
+      return NodeType::Serialize(node, serialize_buffer, value_serializer);
     };
-    serialization::SerializeVectorLike<GraphNodeType, GraphNodeVector>(
+    serialization::SerializeVectorLike<NodeType, NodeVector>(
         nodes_, buffer, graph_node_serializer);
     // Figure out how many bytes were written
     const uint64_t end_buffer_size = buffer.size();
@@ -607,15 +598,15 @@ public:
       const std::vector<uint8_t>& buffer, const uint64_t starting_offset,
       const serialization::Deserializer<NodeValueType>& value_deserializer)
   {
-    const serialization::Deserializer<GraphNodeType> graph_node_deserializer =
+    const serialization::Deserializer<NodeType> graph_node_deserializer =
         [&] (const std::vector<uint8_t>& deserialize_buffer,
              const uint64_t offset)
     {
-      return GraphNodeType::Deserialize(
+      return NodeType::Deserialize(
           deserialize_buffer, offset, value_deserializer);
     };
     const auto deserialized_nodes
-        = serialization::DeserializeVectorLike<GraphNodeType, GraphNodeVector>(
+        = serialization::DeserializeVectorLike<NodeType, NodeVector>(
             buffer, starting_offset, graph_node_deserializer);
 
     GraphType temp_graph;
@@ -678,21 +669,21 @@ public:
     return simple_graph::CheckGraphLinkage(*this);
   }
 
-  const GraphNodeVector& GetNodesImmutable() const { return nodes_; }
+  const NodeVector& GetNodesImmutable() const { return nodes_; }
 
-  GraphNodeVector& GetNodesMutable() { return nodes_; }
+  NodeVector& GetNodesMutable() { return nodes_; }
 
-  const GraphNodeType& GetNodeImmutable(const int64_t index) const
+  const NodeType& GetNodeImmutable(const int64_t index) const
   {
     return nodes_.at(static_cast<size_t>(index));
   }
 
-  GraphNodeType& GetNodeMutable(const int64_t index)
+  NodeType& GetNodeMutable(const int64_t index)
   {
     return nodes_.at(static_cast<size_t>(index));
   }
 
-  int64_t AddNode(const GraphNodeType& new_node)
+  int64_t AddNode(const NodeType& new_node)
   {
     nodes_.push_back(new_node);
     return static_cast<int64_t>(nodes_.size() - 1);
@@ -708,14 +699,14 @@ public:
                            const double edge_weight)
   {
     // We retrieve the nodes first, since retrieval performs bounds checks first
-    GraphNodeType& from_node = GetNodeMutable(from_index);
-    GraphNodeType& to_node = GetNodeMutable(to_index);
+    NodeType& from_node = GetNodeMutable(from_index);
+    NodeType& to_node = GetNodeMutable(to_index);
     if (from_index == to_index)
     {
       throw std::invalid_argument(
           "Invalid circular edge from == to not allowed");
     }
-    const GraphEdge new_edge(from_index, to_index, edge_weight);
+    const EdgeType new_edge(from_index, to_index, edge_weight);
     from_node.AddOutEdge(new_edge);
     to_node.AddInEdge(new_edge);
   }
@@ -725,17 +716,17 @@ public:
                             const double edge_weight)
   {
     // We retrieve the nodes first, since retrieval performs bounds checks first
-    GraphNodeType& first_node = GetNodeMutable(first_index);
-    GraphNodeType& second_node = GetNodeMutable(second_index);
+    NodeType& first_node = GetNodeMutable(first_index);
+    NodeType& second_node = GetNodeMutable(second_index);
     if (first_index == second_index)
     {
       throw std::invalid_argument(
           "Invalid circular edge first == second not allowed");
     }
-    const GraphEdge first_edge(first_index, second_index, edge_weight);
+    const EdgeType first_edge(first_index, second_index, edge_weight);
     first_node.AddOutEdge(first_edge);
     second_node.AddInEdge(first_edge);
-    const GraphEdge second_edge(second_index, first_index, edge_weight);
+    const EdgeType second_edge(second_index, first_index, edge_weight);
     second_node.AddOutEdge(second_edge);
     first_node.AddInEdge(second_edge);
   }
@@ -744,16 +735,40 @@ public:
 template<typename NodeValueType, typename GraphType>
 class NonOwningGraphOverlay
 {
-private:
-  using GraphNodeType = GraphNode<NodeValueType>;
+public:
+  using NodeType = GraphNode<NodeValueType>;
+  using EdgeType = typename NodeType::EdgeType;
 
-  const GraphType& base_graph_;
-  std::unordered_map<int64_t, GraphNodeType> overlay_;
+private:
+  using NodeOverlayType = std::unordered_map<
+      int64_t, NodeType, std::hash<int64_t>, std::equal_to<int64_t>,
+      Eigen::aligned_allocator<std::pair<const int64_t, NodeType>>>;
+
+  const GraphType* base_graph_ = nullptr;
+  NodeOverlayType overlay_;
   int64_t size_ = 0;
+
+protected:
+  const GraphType& GetBaseGraphImmutable() const { return *base_graph_; }
 
 public:
   NonOwningGraphOverlay(const GraphType& graph)
-      : base_graph_(graph), size_(graph.Size()) {}
+      : NonOwningGraphOverlay(std::addressof(graph)) {}
+
+  NonOwningGraphOverlay(const GraphType* const graph) : base_graph_(graph)
+  {
+    if (base_graph_ != nullptr)
+    {
+      size_ = GetBaseGraphImmutable().Size();
+    }
+    else
+    {
+      throw std::invalid_argument(
+          "Cannot construct NonOwningGraphOverlay with nullptr graph");
+    }
+  }
+
+  virtual ~NonOwningGraphOverlay() {}
 
   int64_t Size() const { return size_; }
 
@@ -774,7 +789,7 @@ public:
     return simple_graph::CheckGraphLinkage(*this);
   }
 
-  const GraphNodeType& GetNodeImmutable(const int64_t index) const
+  const NodeType& GetNodeImmutable(const int64_t index) const
   {
     const auto overlay_node = overlay_.find(index);
     if (overlay_node != overlay_.end())
@@ -783,11 +798,11 @@ public:
     }
     else
     {
-      return base_graph_.GetNodeImmutable(index);
+      return GetBaseGraphImmutable().GetNodeImmutable(index);
     }
   }
 
-  GraphNodeType& GetNodeMutable(const int64_t index)
+  NodeType& GetNodeMutable(const int64_t index)
   {
     auto overlay_node = overlay_.find(index);
     if (overlay_node != overlay_.end())
@@ -797,13 +812,14 @@ public:
     else
     {
       // The node must be migrated to the overlay first.
-      const GraphNodeType& base_node = base_graph_.GetNodeImmutable(index);
+      const NodeType& base_node =
+          GetBaseGraphImmutable().GetNodeImmutable(index);
       auto result = overlay_.emplace(index, base_node);
       return result.first->second;
     }
   }
 
-  int64_t AddNode(const GraphNodeType& new_node)
+  int64_t AddNode(const NodeType& new_node)
   {
     const int64_t new_node_index = Size();
     overlay_.emplace(new_node_index, new_node);
@@ -814,7 +830,7 @@ public:
   int64_t AddNode(const NodeValueType& new_value)
   {
     const int64_t new_node_index = Size();
-    overlay_.emplace(new_node_index, GraphNodeType(new_value));
+    overlay_.emplace(new_node_index, NodeType(new_value));
     size_++;
     return new_node_index;
   }
@@ -834,11 +850,11 @@ public:
     }
 
     // We retrieve the nodes, which migrates them to the overlay first.
-    GraphNodeType& from_node = GetNodeMutable(from_index);
-    GraphNodeType& to_node = GetNodeMutable(to_index);
+    NodeType& from_node = GetNodeMutable(from_index);
+    NodeType& to_node = GetNodeMutable(to_index);
 
     // Add the new edge.
-    const GraphEdge new_edge(from_index, to_index, edge_weight);
+    const EdgeType new_edge(from_index, to_index, edge_weight);
     from_node.AddOutEdge(new_edge);
     to_node.AddInEdge(new_edge);
   }
@@ -860,14 +876,14 @@ public:
     }
 
     // We retrieve the nodes, which migrates them to the overlay first.
-    GraphNodeType& first_node = GetNodeMutable(first_index);
-    GraphNodeType& second_node = GetNodeMutable(second_index);
+    NodeType& first_node = GetNodeMutable(first_index);
+    NodeType& second_node = GetNodeMutable(second_index);
 
     // Add the new edges.
-    const GraphEdge first_edge(first_index, second_index, edge_weight);
+    const EdgeType first_edge(first_index, second_index, edge_weight);
     first_node.AddOutEdge(first_edge);
     second_node.AddInEdge(first_edge);
-    const GraphEdge second_edge(second_index, first_index, edge_weight);
+    const EdgeType second_edge(second_index, first_index, edge_weight);
     second_node.AddOutEdge(second_edge);
     first_node.AddInEdge(second_edge);
   }
@@ -887,7 +903,8 @@ public:
         }
         else
         {
-          return "(base) " + base_graph_.GetNodeImmutable(index).Print();
+          return "(base) " +
+              GetBaseGraphImmutable().GetNodeImmutable(index).Print();
         }
       };
 
@@ -899,6 +916,18 @@ public:
     }
     return strm.str();
   }
+};
+
+template<typename NodeValueType, typename GraphType>
+class OwningGraphOverlay : NonOwningGraphOverlay<NodeValueType, GraphType>
+{
+private:
+  std::shared_ptr<const GraphType> owned_base_graph_;
+
+public:
+  OwningGraphOverlay(const std::shared_ptr<const GraphType>& owned_base_graph)
+      : NonOwningGraphOverlay<NodeValueType, GraphType>(owned_base_graph.get()),
+        owned_base_graph_(owned_base_graph) {}
 };
 
 inline std::ostream& operator<< (std::ostream& stream, const GraphEdge& edge)

--- a/include/common_robotics_utilities/simple_graph_search.hpp
+++ b/include/common_robotics_utilities/simple_graph_search.hpp
@@ -177,10 +177,10 @@ inline DijkstrasResult PerformDijkstrasAlgorithm(
       // Note that we've been here
       explored.insert(top_node.Index());
       // Get our neighbors
-      const std::vector<simple_graph::GraphEdge>& neighbor_edges
+      const auto& neighbor_edges
           = graph.GetNodeImmutable(top_node.Index()).GetInEdgesImmutable();
       // Go through our neighbors
-      for (const simple_graph::GraphEdge& neighbor_edge : neighbor_edges)
+      for (const auto& neighbor_edge : neighbor_edges)
       {
         const int64_t neighbor_index = neighbor_edge.GetFromIndex();
         const double neighbor_edge_weight = neighbor_edge.GetWeight();
@@ -234,9 +234,9 @@ inline AstarIndexResult PerformLazyAstarSearch(
         const GraphType&, const int64_t)>& goal_check_fn,
     const std::function<bool(
         const GraphType&,
-        const simple_graph::GraphEdge&)>& edge_validity_check_fn,
+        const typename GraphType::EdgeType&)>& edge_validity_check_fn,
     const std::function<double(
-        const GraphType&, const simple_graph::GraphEdge&)>& distance_fn,
+        const GraphType&, const typename GraphType::EdgeType&)>& distance_fn,
     const std::function<double(
         const GraphType&, const int64_t)>& heuristic_fn,
     const bool limit_pqueue_duplicates)
@@ -343,7 +343,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
       }
 
       // Explore and add the children
-      const std::vector<simple_graph::GraphEdge>& out_edges
+      const auto& out_edges
           = graph.GetNodeImmutable(top_node.State()).GetOutEdgesImmutable();
 
       for (const auto& current_out_edge : out_edges)
@@ -428,9 +428,10 @@ inline AstarIndexResult PerformLazyAstarSearch(
     const std::vector<int64_t>& goal_indices,
     const std::function<bool(
         const GraphType&,
-        const simple_graph::GraphEdge&)>& edge_validity_check_fn,
+        const typename GraphType::EdgeType&)>& edge_validity_check_fn,
     const std::function<double(
-        const GraphType&, const simple_graph::GraphEdge&)>& distance_fn,
+        const GraphType&,
+        const typename GraphType::EdgeType&)>& distance_fn,
     const std::function<double(
         const GraphType&, const int64_t, const int64_t)>& heuristic_fn,
     const bool limit_pqueue_duplicates)
@@ -512,7 +513,8 @@ inline AstarIndexResult PerformLazyAstarSearch(
 {
   // Wrap the helper functions
   const auto edge_validity_check_function
-      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph,
+             const typename GraphType::EdgeType& edge)
   {
     return edge_validity_check_fn(
         search_graph.GetNodeImmutable(edge.GetFromIndex()).GetValueImmutable(),
@@ -520,7 +522,8 @@ inline AstarIndexResult PerformLazyAstarSearch(
   };
 
   const auto distance_function
-      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph,
+             const typename GraphType::EdgeType& edge)
   {
     return distance_fn(
         search_graph.GetNodeImmutable(edge.GetFromIndex()).GetValueImmutable(),
@@ -551,7 +554,8 @@ inline AstarIndexResult PerformAstarSearch(
     const bool limit_pqueue_duplicates)
 {
   const auto edge_validity_check_function
-      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph,
+             const typename GraphType::EdgeType& edge)
   {
     CRU_UNUSED(search_graph);
     if (edge.GetWeight() < std::numeric_limits<double>::infinity())
@@ -564,7 +568,8 @@ inline AstarIndexResult PerformAstarSearch(
     }
   };
   const auto distance_function
-      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph,
+             const typename GraphType::EdgeType& edge)
   {
     CRU_UNUSED(search_graph);
     return edge.GetWeight();

--- a/include/common_robotics_utilities/simple_graph_search.hpp
+++ b/include/common_robotics_utilities/simple_graph_search.hpp
@@ -142,9 +142,9 @@ public:
   }
 };
 
-template<typename NodeValueType>
+template<typename GraphType>
 inline DijkstrasResult PerformDijkstrasAlgorithm(
-    const simple_graph::Graph<NodeValueType>& graph, const int64_t start_index)
+    const GraphType& graph, const int64_t start_index)
 {
   if (!graph.IndexInRange(start_index))
   {
@@ -226,22 +226,19 @@ using AstarIndexPQueueElement =
 using CompareAstarIndexPQueueElementFn =
     simple_astar_search::CompareAstarPQueueElementFn<int64_t>;
 
-template<typename NodeValueType>
+template<typename GraphType>
 inline AstarIndexResult PerformLazyAstarSearch(
-    const simple_graph::Graph<NodeValueType>& graph,
+    const GraphType& graph,
     const IndexStatesWithCosts& start_indices,
     const std::function<bool(
-        const simple_graph::Graph<NodeValueType>&,
-        const int64_t)>& goal_check_fn,
+        const GraphType&, const int64_t)>& goal_check_fn,
     const std::function<bool(
-        const simple_graph::Graph<NodeValueType>&,
+        const GraphType&,
         const simple_graph::GraphEdge&)>& edge_validity_check_fn,
     const std::function<double(
-        const simple_graph::Graph<NodeValueType>&,
-        const simple_graph::GraphEdge&)>& distance_fn,
+        const GraphType&, const simple_graph::GraphEdge&)>& distance_fn,
     const std::function<double(
-        const simple_graph::Graph<NodeValueType>&,
-        const int64_t)>& heuristic_fn,
+        const GraphType&, const int64_t)>& heuristic_fn,
     const bool limit_pqueue_duplicates)
 {
   // Sanity check
@@ -424,19 +421,18 @@ inline AstarIndexResult PerformLazyAstarSearch(
   }
 }
 
-template<typename NodeValueType>
+template<typename GraphType>
 inline AstarIndexResult PerformLazyAstarSearch(
-    const simple_graph::Graph<NodeValueType>& graph,
+    const GraphType& graph,
     const std::vector<int64_t>& start_indices,
     const std::vector<int64_t>& goal_indices,
     const std::function<bool(
-        const simple_graph::Graph<NodeValueType>&,
+        const GraphType&,
         const simple_graph::GraphEdge&)>& edge_validity_check_fn,
     const std::function<double(
-        const simple_graph::Graph<NodeValueType>&,
-        const simple_graph::GraphEdge&)>& distance_fn,
-    const std::function<double(const simple_graph::Graph<NodeValueType>&,
-                               const int64_t, const int64_t)>& heuristic_fn,
+        const GraphType&, const simple_graph::GraphEdge&)>& distance_fn,
+    const std::function<double(
+        const GraphType&, const int64_t, const int64_t)>& heuristic_fn,
     const bool limit_pqueue_duplicates)
 {
   // Enforced sanity checks
@@ -458,8 +454,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
 
   // Make goal check function
   const auto goal_check_function = [&] (
-      const simple_graph::Graph<NodeValueType>& search_graph,
-      const int64_t node_index)
+      const GraphType& search_graph, const int64_t node_index)
   {
     CRU_UNUSED(search_graph);
     for (const int64_t goal_index : goal_indices)
@@ -474,8 +469,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
 
   // Make heuristic helper function
   const auto heuristic_function = [&] (
-      const simple_graph::Graph<NodeValueType>& search_graph,
-      const int64_t node_index)
+      const GraphType& search_graph, const int64_t node_index)
   {
     double best_heuristic_value = std::numeric_limits<double>::infinity();
     for (const int64_t goal_index : goal_indices)
@@ -497,15 +491,15 @@ inline AstarIndexResult PerformLazyAstarSearch(
     start_indices_with_costs.emplace_back(start_index, 0.0);
   }
 
-  return PerformLazyAstarSearch<NodeValueType>(
+  return PerformLazyAstarSearch<GraphType>(
       graph, start_indices_with_costs, goal_check_function,
       edge_validity_check_fn, distance_fn, heuristic_function,
       limit_pqueue_duplicates);
 }
 
-template<typename NodeValueType>
+template<typename NodeValueType, typename GraphType>
 inline AstarIndexResult PerformLazyAstarSearch(
-    const simple_graph::Graph<NodeValueType>& graph,
+    const GraphType& graph,
     const std::vector<int64_t>& start_indices,
     const std::vector<int64_t>& goal_indices,
     const std::function<bool(const NodeValueType&,
@@ -518,8 +512,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
 {
   // Wrap the helper functions
   const auto edge_validity_check_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
-             const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
   {
     return edge_validity_check_fn(
         search_graph.GetNodeImmutable(edge.GetFromIndex()).GetValueImmutable(),
@@ -527,8 +520,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
   };
 
   const auto distance_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
-             const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
   {
     return distance_fn(
         search_graph.GetNodeImmutable(edge.GetFromIndex()).GetValueImmutable(),
@@ -536,7 +528,7 @@ inline AstarIndexResult PerformLazyAstarSearch(
   };
 
   const auto heuristic_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
+      = [&] (const GraphType& search_graph,
              const int64_t from_index, const int64_t to_index)
   {
     return heuristic_fn(
@@ -544,14 +536,14 @@ inline AstarIndexResult PerformLazyAstarSearch(
         search_graph.GetNodeImmutable(to_index).GetValueImmutable());
   };
 
-  return PerformLazyAstarSearch<NodeValueType>(
+  return PerformLazyAstarSearch<GraphType>(
       graph, start_indices, goal_indices, edge_validity_check_function,
       distance_function, heuristic_function, limit_pqueue_duplicates);
 }
 
-template<typename NodeValueType>
+template<typename NodeValueType, typename GraphType>
 inline AstarIndexResult PerformAstarSearch(
-    const simple_graph::Graph<NodeValueType>& graph,
+    const GraphType& graph,
     const std::vector<int64_t>& start_indices,
     const std::vector<int64_t>& goal_indices,
     const std::function<double(const NodeValueType&,
@@ -559,8 +551,7 @@ inline AstarIndexResult PerformAstarSearch(
     const bool limit_pqueue_duplicates)
 {
   const auto edge_validity_check_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
-             const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
   {
     CRU_UNUSED(search_graph);
     if (edge.GetWeight() < std::numeric_limits<double>::infinity())
@@ -573,21 +564,20 @@ inline AstarIndexResult PerformAstarSearch(
     }
   };
   const auto distance_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
-             const simple_graph::GraphEdge& edge)
+      = [&] (const GraphType& search_graph, const simple_graph::GraphEdge& edge)
   {
     CRU_UNUSED(search_graph);
     return edge.GetWeight();
   };
   const auto heuristic_function
-      = [&] (const simple_graph::Graph<NodeValueType>& search_graph,
+      = [&] (const GraphType& search_graph,
              const int64_t from_index, const int64_t to_index)
   {
     return heuristic_fn(
         search_graph.GetNodeImmutable(from_index).GetValueImmutable(),
         search_graph.GetNodeImmutable(to_index).GetValueImmutable());
   };
-  return PerformLazyAstarSearch<NodeValueType>(
+  return PerformLazyAstarSearch<GraphType>(
       graph, start_indices, goal_indices, edge_validity_check_function,
       distance_function, heuristic_function, limit_pqueue_duplicates);
 }

--- a/include/common_robotics_utilities/simple_prm_planner.hpp
+++ b/include/common_robotics_utilities/simple_prm_planner.hpp
@@ -60,11 +60,11 @@ inline int64_t AddNodeToRoadmap(
     const bool add_duplicate_states = false)
 {
   // Make the node->graph or graph->node distance function as needed
-  std::function<double(const simple_graph::GraphNode<T>&, const T&)>
+  std::function<double(const typename GraphType::NodeType&, const T&)>
       graph_distance_fn = nullptr;
   if (nn_distance_direction == NNDistanceDirection::ROADMAP_TO_NEW_STATE)
   {
-    graph_distance_fn = [&] (const simple_graph::GraphNode<T>& node,
+    graph_distance_fn = [&] (const typename GraphType::NodeType& node,
                              const T& query_state)
     {
       return distance_fn(node.GetValueImmutable(), query_state);
@@ -72,7 +72,7 @@ inline int64_t AddNodeToRoadmap(
   }
   else
   {
-    graph_distance_fn = [&] (const simple_graph::GraphNode<T>& node,
+    graph_distance_fn = [&] (const typename GraphType::NodeType& node,
                              const T& query_state)
     {
       return distance_fn(query_state, node.GetValueImmutable());
@@ -91,7 +91,7 @@ inline int64_t AddNodeToRoadmap(
 
     size_t size() const { return static_cast<size_t>(roadmap_.Size()); }
 
-    const simple_graph::GraphNode<T>& operator[](const size_t index) const
+    const typename GraphType::NodeType& operator[](const size_t index) const
     {
       return roadmap_.GetNodeImmutable(static_cast<int64_t>(index));
     }
@@ -303,17 +303,13 @@ inline void UpdateRoadMapEdges(
   for (int64_t current_node_index = 0; current_node_index < roadmap.Size();
        current_node_index++)
   {
-    simple_graph::GraphNode<T>& current_node
-        = roadmap.GetNodeMutable(current_node_index);
-    std::vector<simple_graph::GraphEdge>& current_node_out_edges
-        = current_node.GetOutEdgesMutable();
+    auto& current_node = roadmap.GetNodeMutable(current_node_index);
+    auto& current_node_out_edges = current_node.GetOutEdgesMutable();
     for (auto& current_out_edge : current_node_out_edges)
     {
       const int64_t other_node_idx = current_out_edge.GetToIndex();
-      simple_graph::GraphNode<T>& other_node
-          = roadmap.GetNodeMutable(other_node_idx);
-      std::vector<simple_graph::GraphEdge>& other_node_in_edges
-          = other_node.GetInEdgesMutable();
+      auto& other_node = roadmap.GetNodeMutable(other_node_idx);
+      auto& other_node_in_edges = other_node.GetInEdgesMutable();
       const double updated_weight
           = (edge_validity_check_fn(current_node.GetValueImmutable(),
                                     other_node.GetValueImmutable()))

--- a/test/planning_test.cpp
+++ b/test/planning_test.cpp
@@ -217,9 +217,8 @@ void DrawRoadmap(
   const auto& roadmap_nodes = roadmap.GetNodesImmutable();
   for (const auto& roadmap_node : roadmap_nodes)
   {
-    const std::vector<simple_graph::GraphEdge>& out_edges
-        = roadmap_node.GetOutEdgesImmutable();
-    for (const simple_graph::GraphEdge& edge : out_edges)
+    const auto& out_edges = roadmap_node.GetOutEdgesImmutable();
+    for (const auto& edge : out_edges)
     {
       const Waypoint& self
           = roadmap.GetNodeImmutable(edge.GetFromIndex()).GetValueImmutable();

--- a/test/planning_test.cpp
+++ b/test/planning_test.cpp
@@ -404,7 +404,7 @@ GTEST_TEST(PlanningTest, Test)
   };
 
   // Build a roadmap on the environment
-  const size_t K = 5;
+  const int64_t K = 5;
   const int64_t roadmap_size = 100;
   const std::function<bool(const int64_t)> roadmap_termination_fn
       = [] (const int64_t current_roadmap_size)
@@ -513,17 +513,19 @@ GTEST_TEST(PlanningTest, Test)
         // Plan with PRM
         std::cout << "PRM Path (" << print::Print(start) << " to "
                   << print::Print(goal) << ")" << std::endl;
-        const auto path = simple_prm_planner::QueryPath<Waypoint>(
-            {start}, {goal}, loaded_roadmap, WaypointDistance,
-            check_edge_validity_fn, K, false, true, false, true).Path();
+        const auto path =
+            simple_prm_planner::QueryPath<Waypoint, WaypointVector>(
+                {start}, {goal}, loaded_roadmap, WaypointDistance,
+                check_edge_validity_fn, K, false, true, false, true).Path();
         check_plan(test_env, {start}, {goal}, path);
 
         // Plan with Lazy-PRM
         std::cout << "Lazy-PRM Path (" << print::Print(start) << " to "
                   << print::Print(goal) << ")" << std::endl;
-        const auto lazy_path = simple_prm_planner::LazyQueryPath<Waypoint>(
-            {start}, {goal}, loaded_roadmap, WaypointDistance,
-            check_edge_validity_fn, K, false, true, false, true).Path();
+        const auto lazy_path =
+            simple_prm_planner::LazyQueryPath<Waypoint, WaypointVector>(
+                {start}, {goal}, loaded_roadmap, WaypointDistance,
+                check_edge_validity_fn, K, false, true, false, true).Path();
         check_plan(test_env, {start}, {goal}, lazy_path);
 
         // Plan with A*


### PR DESCRIPTION
Changes to graph search methods:

1. Make graph Dijkstra's and A* search templated on graph type, to allow for different graph types without using inheritance
2. Add a graph overlay type, exploiting (1) to add a mutable overlay to an immutable base graph that is compatible with graph search methods
3. Use (2) to make non-adding roadmap queries not require a temporary mutable copy of the provided roadmap

Related quality-of-life changes:

1. Make KNN parameter `K` be `int64_t` instead of `size_t`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/48)
<!-- Reviewable:end -->
