### PR TITLE
Suppress unused variable warnings/errors when OpenMP is disabled

### DIFF
--- a/include/common_robotics_utilities/math.hpp
+++ b/include/common_robotics_utilities/math.hpp
@@ -540,6 +540,8 @@ Eigen::MatrixXd BuildPairwiseDistanceMatrix(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (size_t idx = 0; idx < data.size(); idx++)
   {
@@ -596,6 +598,8 @@ Eigen::MatrixXd BuildPairwiseDistanceMatrix(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (size_t idx = 0; idx < data1.size(); idx++)
   {

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -447,6 +447,8 @@ OutputGraphType PruneGraph(
   // Second, optionally parallel pass to update edges for the kept nodes
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (int64_t kept_node_index = 0; kept_node_index < pruned_graph.Size();
        kept_node_index++)

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -36,6 +36,8 @@ inline std::vector<int32_t> PerformSingleClusteringIteration(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (size_t idx = 0; idx < data.size(); idx++)
   {
@@ -87,6 +89,8 @@ inline Container ComputeClusterCentersWeighted(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+    CRU_UNUSED(use_parallel);
 #endif
     for (size_t cluster = 0; cluster < clustered_data.size(); cluster++)
     {

--- a/include/common_robotics_utilities/simple_prm_planner.hpp
+++ b/include/common_robotics_utilities/simple_prm_planner.hpp
@@ -112,6 +112,8 @@ inline int64_t AddNodeToRoadmap(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (size_t idx = 0; idx < nearest_neighbors.size(); idx++)
   {
@@ -369,6 +371,8 @@ GraphType BuildRoadMap(
   const bool use_parallel_sampling = use_parallel && add_duplicate_states;
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel_sampling)
+#else
+  CRU_UNUSED(use_parallel_sampling);
 #endif
   for (size_t index = 0; index < roadmap_states.size(); index++)
   {
@@ -526,6 +530,8 @@ inline void UpdateRoadMapEdges(
 
 #if defined(_OPENMP)
 #pragma omp parallel for if (use_parallel)
+#else
+  CRU_UNUSED(use_parallel);
 #endif
   for (int64_t current_node_index = 0; current_node_index < roadmap.Size();
        current_node_index++)


### PR DESCRIPTION
After switching to use OpenMP `#pragma omp parallel if (use_parallel)`-style optional parallelization, there are cases in which consuming code without OpenMP enabled will get errors due to `use_parallel` being unused. This PR adds `CRU_UNUSED()` calls if OpenMP is not enabled to suppress these warnings/errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/51)
<!-- Reviewable:end -->
