### PR TITLE
Fix missing include of utility.hpp not found in Catkin/Colcon

### DIFF
--- a/include/common_robotics_utilities/math.hpp
+++ b/include/common_robotics_utilities/math.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
+#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {


### PR DESCRIPTION
Building CRU with Bazel has identified that `math.hpp` was missing an include of `utility.hpp` since #51, however, this was not identified in builds using Catkin or Colcon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/53)
<!-- Reviewable:end -->
