### PR TITLE
Clean up/standardize logging and move ROS 2 print support

### DIFF
--- a/example/clustering_example.cpp
+++ b/example/clustering_example.cpp
@@ -167,11 +167,15 @@ int main(int argc, char** argv)
     {
       return common_robotics_utilities::math::AverageEigenVector4d(cluster);
     };
+    const auto logging_fn = [] (const std::string& message)
+    {
+      std::cout << message << std::endl;
+    };
     const auto kmeans_start = std::chrono::steady_clock::now();
     const std::vector<int32_t> kmeans_labels
         = common_robotics_utilities::simple_kmeans_clustering::Cluster(
             random_points, distance_fn, average_fn, num_clusters, 42, true,
-            use_parallel);
+            use_parallel, logging_fn);
     const auto kmeans_end = std::chrono::steady_clock::now();
     const double kmeans_elapsed =
         std::chrono::duration<double>(kmeans_end - kmeans_start).count();

--- a/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
+++ b/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/include/common_robotics_utilities/path_processing.hpp
+++ b/include/common_robotics_utilities/path_processing.hpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <random>
 #include <stdexcept>
 #include <vector>
@@ -181,10 +180,6 @@ inline Container AttemptShortcut(
             second_half_shortcut.end());
       }
       return shortcut;
-    }
-    else
-    {
-      std::cerr << "Window size < 2, cannot backtrack" << std::endl;
     }
   }
   // If we get here, the shortcut failed and we return an empty shortcut path

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <iomanip>
 #include <array>
 #include <vector>
@@ -11,58 +10,18 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <common_robotics_utilities/utility.hpp>
-#include <Eigen/Geometry>
 
-#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
-#include <rosidl_runtime_cpp/traits.hpp>
-// On pre-Humble distributions, a single message header is included to ensure
-// that rosidl_generator_traits::to_yaml is found by the compiler. The version
-// header is only present in Humble or later, so we use the absence of the file
-// to detect earlier distributions.
-#if !__has_include(<rclcpp/version.h>)
-#include <builtin_interfaces/msg/duration.hpp>
-#endif
-#endif
+#include <Eigen/Geometry>
+#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
 namespace print
 {
-namespace internal
-{
-#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
-struct ROSMessagePrinter
-{
-  template <typename T>
-  static std::string Print(const T& message)
-  {
-#if !__has_include(<rclcpp/version.h>)
-    // ROS 2 Galactic only supports block-style output.
-    return rosidl_generator_traits::to_yaml(message);
-#else
-    // ROS 2 Humble and later support optional flow-style output found via ADL.
-    constexpr bool use_flow_style = true;
-    return to_yaml(message, use_flow_style);
-#endif
-  }
-};
-#endif
-struct GenericPrinter
-{
-  template <typename T>
-  static std::string Print(const T& value)
-  {
-    std::ostringstream strm;
-    strm << value;
-    return strm.str();
-  }
-};
-}  // namespace internal
-
 // Base template function for printing types
 template <typename T>
 inline std::string Print(const T& toprint,
@@ -71,14 +30,9 @@ inline std::string Print(const T& toprint,
 {
   CRU_UNUSED(add_delimiters);
   CRU_UNUSED(separator);
-#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
-  using Printer = typename std::conditional<
-      rosidl_generator_traits::is_message<T>::value,
-      internal::ROSMessagePrinter, internal::GenericPrinter>::type;
-#else
-  using Printer = internal::GenericPrinter;
-#endif
-  return Printer::Print(toprint);
+  std::ostringstream strm;
+  strm << toprint;
+  return strm.str();
 }
 
 ///////////////////////////////////////////////////////////////////

--- a/include/common_robotics_utilities/ros_helpers.hpp
+++ b/include/common_robotics_utilities/ros_helpers.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
+#include <ostream>
+#include <type_traits>
 #include <vector>
 
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+#include <rosidl_runtime_cpp/traits.hpp>
+// On pre-Humble distributions, a single message header is included to ensure
+// that rosidl_generator_traits::to_yaml is found by the compiler. The version
+// header is only present in Humble or later, so we use the absence of the file
+// to detect earlier distributions.
+#if !__has_include(<rclcpp/version.h>)
+#include <builtin_interfaces/msg/duration.hpp>
+#endif
 #include <rclcpp/time.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -14,11 +24,31 @@
 #error "Undefined or unknown COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION"
 #endif
 
+/// Define an ostream operator for ROS 2 message types.
+namespace std
+{
+#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+template <typename T>
+enable_if_t<rosidl_generator_traits::is_message<T>::value, ostream>&
+operator<<(ostream& os, const T& message)
+{
+#if !__has_include(<rclcpp/version.h>)
+  // ROS 2 Galactic only supports block-style output.
+  os << rosidl_generator_traits::to_yaml(message);
+#else
+  // ROS 2 Humble and later support optional flow-style output found via ADL.
+  constexpr bool use_flow_style = false;
+  os << to_yaml(message, use_flow_style);
+#endif
+  return os;
+}
+#endif
+}  // namespace
+
 namespace common_robotics_utilities
 {
 namespace ros_helpers
 {
-
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 using RosTime = rclcpp::Time;
 #elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
@@ -42,7 +72,8 @@ using VisualizationMarker = visualization_msgs::Marker;
 using VisualizationMarkerArray = visualization_msgs::MarkerArray;
 #endif
 
-inline void SetMessageTimestamps(VisualizationMarkerArray& markers, const RosTime& timestamp)
+inline void SetMessageTimestamps(
+    VisualizationMarkerArray& markers, const RosTime& timestamp)
 {
   SetMessageTimestamps<VisualizationMarker>(markers.markers, timestamp);
 }

--- a/include/common_robotics_utilities/ros_helpers.hpp
+++ b/include/common_robotics_utilities/ros_helpers.hpp
@@ -24,10 +24,10 @@
 #error "Undefined or unknown COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION"
 #endif
 
+#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 /// Define an ostream operator for ROS 2 message types.
 namespace std
 {
-#if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 template <typename T>
 enable_if_t<rosidl_generator_traits::is_message<T>::value, ostream>&
 operator<<(ostream& os, const T& message)
@@ -42,8 +42,8 @@ operator<<(ostream& os, const T& message)
 #endif
   return os;
 }
+}  // namespace std
 #endif
-}  // namespace
 
 namespace common_robotics_utilities
 {

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -334,20 +334,17 @@ bool CheckGraphLinkage(const GraphType& graph)
       const int64_t from_index = current_edge.GetFromIndex();
       if (from_index < 0 || from_index >= graph.Size())
       {
-        std::cerr << "from_index out of bounds" << std::endl;
         return false;
       }
       // Check to index to make sure it matches our own index
       const int64_t to_index = current_edge.GetToIndex();
       if (to_index != idx)
       {
-        std::cerr << "to_index does not point to current node" << std::endl;
         return false;
       }
       // Check edge validity (edges to ourself are not allowed)
       if (from_index == to_index)
       {
-        std::cerr << "from_index == to_index not allowed" << std::endl;
         return false;
       }
       // Check to make sure that the from index node is linked to us
@@ -365,7 +362,6 @@ bool CheckGraphLinkage(const GraphType& graph)
       }
       if (from_node_connection_valid == false)
       {
-        std::cerr << "from_index connection is invalid" << std::endl;
         return false;
       }
     }
@@ -377,20 +373,17 @@ bool CheckGraphLinkage(const GraphType& graph)
       const int64_t from_index = current_edge.GetFromIndex();
       if (from_index != idx)
       {
-        std::cerr << "from_index does not point to current node" << std::endl;
         return false;
       }
       // Check to index to make sure it's in bounds
       const int64_t to_index = current_edge.GetToIndex();
       if (to_index < 0 || to_index >= graph.Size())
       {
-        std::cerr << "To index out of bounds" << std::endl;
         return false;
       }
       // Check edge validity (edges to ourself are not allowed)
       if (from_index == to_index)
       {
-        std::cerr << "From index == to index not allowed" << std::endl;
         return false;
       }
       // Check to make sure that the to index node is linked to us
@@ -408,7 +401,6 @@ bool CheckGraphLinkage(const GraphType& graph)
       }
       if (to_node_connection_valid == false)
       {
-        std::cerr << "To index connection is invalid" << std::endl;
         return false;
       }
     }

--- a/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
+++ b/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
-#include <iostream>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -150,7 +150,7 @@ inline std::vector<int32_t> ClusterWeighted(
         weighted_average_fn,
     const int32_t num_clusters, const int64_t prng_seed,
     const bool do_preliminary_clustering, const bool use_parallel = false,
-    const utility::LoggingFunction& logging_fn = utility::NoOpLoggingFunction())
+    const utility::LoggingFunction& logging_fn = {})
 {
   if (data.empty())
   {
@@ -158,7 +158,10 @@ inline std::vector<int32_t> ClusterWeighted(
   }
   if (num_clusters == 1)
   {
-    logging_fn("[K-means clustering] Provided num_clusters = 1");
+    if (logging_fn)
+    {
+      logging_fn("[K-means clustering] Provided num_clusters = 1");
+    }
     return std::vector<int32_t>(data.size(), 0u);
   }
   else if (num_clusters == 0)
@@ -175,17 +178,23 @@ inline std::vector<int32_t> ClusterWeighted(
     if (subset_size >= (num_clusters * 5))
     {
       enable_preliminary_clustering = true;
-      logging_fn(
-          "[K-means clustering] Preliminary clustering enabled, using subset "
-          "of " + std::to_string(subset_size) + " datapoints from " +
-          std::to_string(data.size()) + " total");
+      if (logging_fn)
+      {
+        logging_fn(
+            "[K-means clustering] Preliminary clustering enabled, using subset "
+            "of " + std::to_string(subset_size) + " datapoints from " +
+            std::to_string(data.size()) + " total");
+      }
     }
     else
     {
       enable_preliminary_clustering = false;
-      logging_fn(
-          "[K-means clustering] Preliminary clustering disabled as input data "
-          "is too small w.r.t. number of clusters");
+      if (logging_fn)
+      {
+        logging_fn(
+            "[K-means clustering] Preliminary clustering disabled as input data"
+            " is too small w.r.t. number of clusters");
+      }
     }
   }
   // Prepare an RNG for cluster initialization
@@ -283,9 +292,12 @@ inline std::vector<int32_t> ClusterWeighted(
     converged = CheckForConvergence(cluster_labels, new_cluster_labels);
     cluster_labels = new_cluster_labels;
   }
-  logging_fn(
-      "[K-means clustering] Clustering converged after " +
-      std::to_string(iteration) + " iterations");
+  if (logging_fn)
+  {
+    logging_fn(
+        "[K-means clustering] Clustering converged after " +
+        std::to_string(iteration) + " iterations");
+  }
   return cluster_labels;
 }
 
@@ -304,7 +316,7 @@ inline std::vector<int32_t> Cluster(
     const std::function<DataType(const Container&)>& average_fn,
     const int32_t num_clusters, const int64_t prng_seed,
     const bool do_preliminary_clustering, const bool use_parallel = false,
-    const utility::LoggingFunction& logging_fn = utility::NoOpLoggingFunction())
+    const utility::LoggingFunction& logging_fn = {})
 {
   // Make a dummy set of uniform weights
   const std::vector<double> data_weights(data.size(), 1.0);

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -133,9 +133,6 @@ inline bool CheckForConvergence(
   }
 }
 
-/// Typedef of a logging function used by K-means clustering.
-using LoggingFunction = std::function<void(const std::string&)>;
-
 /// Perform K-means clustering of @param data with corresponding weights @param
 /// data_weightd, using @param distance_fn to compute element-to-element
 /// distances and @param weighted_average_fn to compute the center/mean of a set
@@ -153,7 +150,7 @@ inline std::vector<int32_t> ClusterWeighted(
         weighted_average_fn,
     const int32_t num_clusters, const int64_t prng_seed,
     const bool do_preliminary_clustering, const bool use_parallel = false,
-    const LoggingFunction& logging_fn = [] (const std::string&) {})
+    const utility::LoggingFunction& logging_fn = utility::NoOpLoggingFunction())
 {
   if (data.empty())
   {
@@ -307,7 +304,7 @@ inline std::vector<int32_t> Cluster(
     const std::function<DataType(const Container&)>& average_fn,
     const int32_t num_clusters, const int64_t prng_seed,
     const bool do_preliminary_clustering, const bool use_parallel = false,
-    const LoggingFunction& logging_fn = [] (const std::string&) {})
+    const utility::LoggingFunction& logging_fn = utility::NoOpLoggingFunction())
 {
   // Make a dummy set of uniform weights
   const std::vector<double> data_weights(data.size(), 1.0);

--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -319,18 +319,12 @@ public:
       const auto& current_state = nodes.at(current_index);
       if (!current_state.IsInitialized())
       {
-        std::cerr << "Tree contains uninitialized node(s): "
-                  << current_index << std::endl;
         return false;
       }
       // Check the linkage to the parent state
       const int64_t parent_index = current_state.GetParentIndex();
       if (parent_index > static_cast<int64_t>(current_index))
       {
-        std::cerr << "Invalid parent index " << parent_index << " for state "
-                  << current_index
-                  << " [Parent index cannot be greater than our own index]"
-                  << std::endl;
         return false;
       }
       if ((parent_index >= 0)
@@ -343,8 +337,6 @@ public:
           // Make sure the parent state is initialized.
           if (!parent_state.IsInitialized())
           {
-            std::cerr << "Tree contains uninitialized node(s) "
-                      << parent_index << std::endl;
             return false;
           }
           // Make sure the corresponding parent contains the current node in its
@@ -356,25 +348,13 @@ public:
                                        static_cast<int64_t>(current_index));
           if (index_found == parent_child_indices.end())
           {
-            std::cerr << "Parent state " << parent_index
-                      << " does not contain child index for current node "
-                      << current_index << std::endl;
             return false;
           }
         }
         else
         {
-          std::cerr << "Invalid parent index " << parent_index << " for state "
-                    << current_index << " [Parent index cannot be our own index]"
-                    << std::endl;
           return false;
         }
-      }
-      else if (parent_index < -1)
-      {
-        std::cerr << "Invalid parent index " << parent_index << " for state "
-                  << current_index << " [Parent index < -1]" << std::endl;
-        return false;
       }
       // Check the linkage to the child states
       const std::vector<int64_t>& current_child_indices
@@ -390,41 +370,22 @@ public:
                 nodes.at(static_cast<size_t>(current_child_index));
             if (!child_state.IsInitialized())
             {
-              std::cerr << "Tree contains uninitialized node(s) "
-                        << current_child_index << std::endl;
               return false;
             }
             // Make sure the child node points to us as the parent index
             const int64_t child_parent_index = child_state.GetParentIndex();
             if (child_parent_index != static_cast<int64_t>(current_index))
             {
-              std::cerr << "Parent index " << child_parent_index
-                        << " for current child state " << current_child_index
-                        << " does not match index " << current_index
-                        << " for current node " << std::endl;
               return false;
             }
           }
-          else if (current_child_index == static_cast<int64_t>(current_index))
-          {
-            std::cerr << "Invalid child index " << current_child_index
-                      << " for state " << current_index
-                      << " [Child index cannot be our own index]" << std::endl;
-            return false;
-          }
           else
           {
-            std::cerr << "Invalid child index " << current_child_index
-                      << " for state " << current_index
-                      << " [Child index cannot be less than our own index]"
-                      << std::endl;
             return false;
           }
         }
         else
         {
-          std::cerr << "Invalid child index " << current_child_index
-                    << " for state " << current_index << std::endl;
           return false;
         }
       }

--- a/include/common_robotics_utilities/simple_task_planner.hpp
+++ b/include/common_robotics_utilities/simple_task_planner.hpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <map>
 #include <memory>
@@ -16,6 +15,7 @@
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/simple_astar_search.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
+#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
@@ -99,15 +99,6 @@ private:
   std::string name_;
 };
 
-/// Typedef of a logging function used by ActionPrimitiveCollection.
-using LoggingFunction = std::function<void(const std::string&)>;
-
-/// Make a LoggingFunction using std::cout.
-inline LoggingFunction MakeCoutLoggingFunction()
-{
-  return [] (const std::string& message) { std::cout << message << std::endl; };
-}
-
 /// Stores a collection of action primitives, enforcing name uniqueness and
 /// providing useful helpers.
 template<typename State, typename Container=std::vector<State>>
@@ -115,10 +106,11 @@ class ActionPrimitiveCollection
 {
 public:
   explicit ActionPrimitiveCollection(
-      const LoggingFunction& logging_fn = MakeCoutLoggingFunction())
+      const utility::LoggingFunction& logging_fn =
+          utility::NoOpLoggingFunction())
       : logging_fn_(logging_fn) {}
 
-  void SetLoggingFunction(const LoggingFunction& logging_fn)
+  void SetLoggingFunction(const utility::LoggingFunction& logging_fn)
   {
     logging_fn_ = logging_fn;
   }
@@ -177,7 +169,7 @@ public:
 
 private:
   std::vector<ActionPrimitiveSharedPtr<State, Container>> primitives_;
-  LoggingFunction logging_fn_;
+  utility::LoggingFunction logging_fn_;
 };
 
 /// Return a heuristic value for the provided state.
@@ -461,7 +453,6 @@ Container PerformSingleTaskExecution(
     const TaskSequenceCompleteFunction<State>& task_sequence_complete_fn,
     const Container& start_states,
     const int32_t max_primitive_executions = -1,
-    const bool single_step = false,
     const StateHeuristicFunction<State>& state_heuristic_fn = {},
     const StateHash& state_hasher = StateHash(),
     const StateEqual& state_equaler = StateEqual(),
@@ -516,18 +507,8 @@ Container PerformSingleTaskExecution(
       user_pre_action_callback_fn(selected_outcome, next_primitive);
     }
 
-    // Prompt to continue/notify.
-    if (single_step)
-    {
-      std::cout << "Press ENTER to perform primitive ["
-                << next_primitive->Name() << "]" << std::endl;
-      std::cin.get();
-    }
-    else
-    {
-      primitive_collection.Log(
-          "Performing primitive [" + next_primitive->Name() + "]");
-    }
+    primitive_collection.Log(
+        "Performing primitive [" + next_primitive->Name() + "]");
 
     // Execute the primitive.
     num_primitive_executions++;
@@ -551,7 +532,6 @@ Container PerformSingleTaskExecution(
     const TaskSequenceCompleteFunction<State>& task_sequence_complete_fn,
     const State& start_state,
     const int32_t max_primitive_executions = -1,
-    const bool single_step = false,
     const StateHeuristicFunction<State>& state_heuristic_fn = {},
     const StateHash& state_hasher = StateHash(),
     const StateEqual& state_equaler = StateEqual(),
@@ -568,8 +548,8 @@ Container PerformSingleTaskExecution(
 
   return PerformSingleTaskExecution<State, Container, StateHash, StateEqual>(
       primitive_collection, task_sequence_complete_fn, start_states,
-      max_primitive_executions, single_step, state_heuristic_fn, state_hasher,
-      state_equaler, user_pre_action_callback_fn, user_post_execution_callback,
+      max_primitive_executions, state_heuristic_fn, state_hasher, state_equaler,
+      user_pre_action_callback_fn, user_post_execution_callback,
       user_post_outcome_callback_fn);
 }
 }  // namespace simple_task_planner

--- a/include/common_robotics_utilities/simple_task_planner.hpp
+++ b/include/common_robotics_utilities/simple_task_planner.hpp
@@ -106,8 +106,7 @@ class ActionPrimitiveCollection
 {
 public:
   explicit ActionPrimitiveCollection(
-      const utility::LoggingFunction& logging_fn =
-          utility::NoOpLoggingFunction())
+      const utility::LoggingFunction& logging_fn = {})
       : logging_fn_(logging_fn) {}
 
   void SetLoggingFunction(const utility::LoggingFunction& logging_fn)

--- a/include/common_robotics_utilities/voxel_grid.hpp
+++ b/include/common_robotics_utilities/voxel_grid.hpp
@@ -2,8 +2,8 @@
 
 #include <cmath>
 #include <cstdint>
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -1249,8 +1249,6 @@ public:
     }
     else
     {
-      std::cerr << "Failed to load internal data - expected "
-                << expected_length << " got " << data.size() << std::endl;
       return false;
     }
   }

--- a/src/common_robotics_utilities/math.cpp
+++ b/src/common_robotics_utilities/math.cpp
@@ -360,14 +360,14 @@ Eigen::Isometry3d ExpTwist(const Eigen::Matrix<double, 6, 1>& twist,
   }
   else
   {
+    // NOTE: you may encounter numerical instability using ExpTwist(...) with
+    // translation and rotational norm < 1e-100.
     if ((trans_velocity_norm >= 1e-100) || (rot_velocity_norm == 0.0))
     {
       raw_transform.block<3, 1>(0, 3) = trans_velocity * delta_t;
     }
     else
     {
-      std::cerr << "YOU MAY ENCOUNTER NUMERICAL INSTABILITY IN EXPTWIST(...)"
-                   " WITH TRANS & ROT VELOCITY NORM < 1e-100 ***" << std::endl;
       const double scaled_delta_t = delta_t * rot_velocity_norm;
       const Eigen::Vector3d scaled_trans_velocity
           = trans_velocity / rot_velocity_norm;

--- a/test/planning_test.cpp
+++ b/test/planning_test.cpp
@@ -69,7 +69,7 @@ double WaypointDistance(const Waypoint& start, const Waypoint& end)
 Waypoint InterpolateWaypoint(
     const Waypoint& start, const Waypoint& end, const double ratio)
 {
-  const double real_ratio = utility::ClampValueAndWarn(ratio, 0.0, 1.0);
+  const double real_ratio = utility::ClampValue(ratio, 0.0, 1.0);
   const double delta_rows = static_cast<double>(end.first - start.first);
   const double delta_cols = static_cast<double>(end.second - start.second);
   const double raw_interp_rows = delta_rows * real_ratio;

--- a/test/print_test.cpp
+++ b/test/print_test.cpp
@@ -1,15 +1,16 @@
 #include <vector>
 
+#include <common_robotics_utilities/print.hpp>
+#include <common_robotics_utilities/voxel_grid.hpp>
+
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
+#include <common_robotics_utilities/ros_helpers.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #elif COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 1
 #include <geometry_msgs/Point.h>
 #else
 #error "Undefined or unknown COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION"
 #endif
-
-#include <common_robotics_utilities/print.hpp>
-#include <common_robotics_utilities/voxel_grid.hpp>
 
 #include <gtest/gtest.h>
 
@@ -22,8 +23,7 @@ struct DummyType
   int32_t value = 0;
 };
 
-std::ostream& operator<<(
-    std::ostream& os, const test::DummyType& dummy)
+std::ostream& operator<<(std::ostream& os, const test::DummyType& dummy)
 {
   return os << dummy.value;
 }
@@ -36,7 +36,8 @@ namespace print_test
 {
 GTEST_TEST(PrintTest, CanPrintIfADLCanFindStreamOperator)
 {
-  std::cout << print::Print(std::vector<voxel_grid::GridIndex>{{1, 1, 1}}) << std::endl;
+  std::cout << print::Print(std::vector<voxel_grid::GridIndex>{{1, 1, 1}})
+            << std::endl;
   std::cout << print::Print(std::vector<test::DummyType>(3)) << std::endl;
 }
 

--- a/test/ros_helpers_test.cpp
+++ b/test/ros_helpers_test.cpp
@@ -31,6 +31,9 @@ GTEST_TEST(ROSHelpersTest, SetMessageTimestamps)
   for (const auto& marker : marker_array.markers) {
     EXPECT_EQ(marker.header.stamp, expected_stamp);
   }
+  // Test that ROS messages have an ostream operator available.
+  std::cout << "Set message times to:\n"
+            << marker_array.markers.at(0).header.stamp << std::endl;
 }
 
 }  // namespace

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -54,35 +54,43 @@ GTEST_TEST(UtilityTest, GetUniformRandom)
 
 GTEST_TEST(UtilityTest, ClampAndSpread)
 {
+  const utility::LoggingFunction logging_fn = [] (const std::string& msg)
+  {
+    std::cout << msg << std::endl;
+  };
   ASSERT_EQ(utility::ClampValue(1.0, -0.5, 0.5), 0.5);
-  ASSERT_EQ(utility::ClampValueAndWarn(1.0, -0.5, 0.5), 0.5);
+  ASSERT_EQ(utility::ClampValueAndLog(1.0, -0.5, 0.5, logging_fn), 0.5);
 
   ASSERT_EQ(utility::ClampValue(-1.0, -0.5, 0.5), -0.5);
-  ASSERT_EQ(utility::ClampValueAndWarn(-1.0, -0.5, 0.5), -0.5);
+  ASSERT_EQ(utility::ClampValueAndLog(-1.0, -0.5, 0.5, logging_fn), -0.5);
 
   ASSERT_EQ(utility::ClampValue(0.25, -0.5, 0.5), 0.25);
-  ASSERT_EQ(utility::ClampValueAndWarn(0.25, -0.5, 0.5), 0.25);
+  ASSERT_EQ(utility::ClampValueAndLog(0.25, -0.5, 0.5, logging_fn), 0.25);
 
   ASSERT_THROW(utility::ClampValue(1.0, 1.0, -1.0), std::invalid_argument);
   ASSERT_THROW(
-      utility::ClampValueAndWarn(1.0, 1.0, -1.0), std::invalid_argument);
+      utility::ClampValueAndLog(1.0, 1.0, -1.0, logging_fn),
+      std::invalid_argument);
 
   ASSERT_EQ(utility::SpreadValue(1.0, -0.5, 0.0, 0.5), 1.0);
-  ASSERT_EQ(utility::SpreadValueAndWarn(1.0, -0.5, 0.0, 0.5), 1.0);
+  ASSERT_EQ(utility::SpreadValueAndLog(1.0, -0.5, 0.0, 0.5, logging_fn), 1.0);
 
   ASSERT_EQ(utility::SpreadValue(-1.0, -0.5, 0.0, 0.5), -1.0);
-  ASSERT_EQ(utility::SpreadValueAndWarn(-1.0, -0.5, 0.0, 0.5), -1.0);
+  ASSERT_EQ(
+      utility::SpreadValueAndLog(-1.0, -0.5, 0.0, 0.5, logging_fn), -1.0);
 
   ASSERT_EQ(utility::SpreadValue(0.25, -0.5, 0.0, 0.5), 0.5);
-  ASSERT_EQ(utility::SpreadValueAndWarn(0.25, -0.5, 0.0, 0.5), 0.5);
+  ASSERT_EQ(utility::SpreadValueAndLog(0.25, -0.5, 0.0, 0.5, logging_fn), 0.5);
 
   ASSERT_EQ(utility::SpreadValue(-0.25, -0.5, 0.0, 0.5), -0.5);
-  ASSERT_EQ(utility::SpreadValueAndWarn(-0.25, -0.5, 0.0, 0.5), -0.5);
+  ASSERT_EQ(
+      utility::SpreadValueAndLog(-0.25, -0.5, 0.0, 0.5, logging_fn), -0.5);
 
   ASSERT_THROW(
       utility::SpreadValue(1.0, 1.0, 0.0, -1.0), std::invalid_argument);
   ASSERT_THROW(
-      utility::SpreadValueAndWarn(1.0, 1.0, 0.0, -1.0), std::invalid_argument);
+      utility::SpreadValueAndLog(1.0, 1.0, 0.0, -1.0, logging_fn),
+      std::invalid_argument);
 }
 
 GTEST_TEST(UtilityTest, Alignment)


### PR DESCRIPTION
Changes:

1. Removal of legacy `iostream` (`std::cout`/`std::cerr`) logging calls with standardized `LoggingFunction` type.
2. Replacement of `ClampValueAndWarn`/`SpreadValueAndWarn` with `ClampValueAndLog`/`SpreadValueAndLog`
3. Restructures ROS 2 message printing support to use a separate ROS 2 message `ostream` operator defined in `ros_helpers.hpp` instead of the specialized `Print(...)` implementation in `print.hpp` to reduce ROS dependency effects
4. Removal of `single_step` option (and blocking on `std::cin`) from `simple_task_planner.hpp`.

Note that while the behavior removed in (4) is useful, the specific implementation here led to some issues - notably in environments where `std::cin` is not usefully accessible to the process being run - and lacked configurability. Equivalent functionality can be implemented by putting the blocking single-step behavior in the optional pre-action callback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/54)
<!-- Reviewable:end -->
