### PR TITLE
Replace raw omp parallel for pragmas with macros

### DIFF
--- a/include/common_robotics_utilities/math.hpp
+++ b/include/common_robotics_utilities/math.hpp
@@ -1,16 +1,12 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cmath>
 #include <functional>
 #include <map>
 #include <vector>
 
 #include <Eigen/Geometry>
-#include <common_robotics_utilities/utility.hpp>
+#include <common_robotics_utilities/openmp_helpers.hpp>
 
 namespace common_robotics_utilities
 {
@@ -539,11 +535,7 @@ Eigen::MatrixXd BuildPairwiseDistanceMatrix(
 {
   Eigen::MatrixXd distance_matrix(data.size(), data.size());
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (size_t idx = 0; idx < data.size(); idx++)
   {
     for (size_t jdx = idx; jdx < data.size(); jdx++)
@@ -597,11 +589,7 @@ Eigen::MatrixXd BuildPairwiseDistanceMatrix(
 {
   Eigen::MatrixXd distance_matrix(data1.size(), data2.size());
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (size_t idx = 0; idx < data1.size(); idx++)
   {
     for (size_t jdx = 0; jdx < data2.size(); jdx++)

--- a/include/common_robotics_utilities/openmp_helpers.hpp
+++ b/include/common_robotics_utilities/openmp_helpers.hpp
@@ -125,7 +125,7 @@ inline int32_t GetOmpThreadLimit()
 class ChangeOmpNumThreadsWrapper
 {
 public:
-  ChangeOmpNumThreadsWrapper(const int32_t num_threads)
+  explicit ChangeOmpNumThreadsWrapper(const int32_t num_threads)
   {
     if (GetContextNumOmpThreads() > 1)
     {
@@ -164,6 +164,18 @@ public:
   DisableOmpWrapper() : ChangeOmpNumThreadsWrapper(1) {}
 };
 
+/// Macro to stringify tokens for the purposes of the below macros.
+#define CRU_MACRO_STRINGIFY(s) #s
+
+/// Macros to declare OpenMP parallel for loops, handling conditionals as well
+/// as the case of OpenMP being disabled entirely.
+#if defined(_OPENMP)
+#define CRU_OMP_PARALLEL_FOR_IF(enable_parallel) _Pragma(CRU_MACRO_STRINGIFY(omp parallel for if(enable_parallel)))
+#define CRU_OMP_PARALLEL_FOR _Pragma(CRU_MACRO_STRINGIFY(omp parallel for))
+#else
+#define CRU_OMP_PARALLEL_FOR_IF(enable_parallel) (void)(enable_parallel);
+#define CRU_OMP_PARALLEL_FOR
+#endif
 }  // namespace openmp_helpers
 }  // namespace common_robotics_utilities
 

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <algorithm>
 #include <cstdint>
 #include <memory>
@@ -13,6 +9,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/print.hpp>
 #include <common_robotics_utilities/serialization.hpp>
 #include <common_robotics_utilities/utility.hpp>
@@ -437,11 +434,7 @@ OutputGraphType PruneGraph(
   pruned_graph.ShrinkToFit();
 
   // Second, optionally parallel pass to update edges for the kept nodes
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (int64_t kept_node_index = 0; kept_node_index < pruned_graph.Size();
        kept_node_index++)
   {

--- a/include/common_robotics_utilities/simple_hausdorff_distance.hpp
+++ b/include/common_robotics_utilities/simple_hausdorff_distance.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -55,9 +51,7 @@ inline double ComputeDistanceParallel(
   // Make per-thread storage
   std::vector<double> per_thread_storage(
       openmp_helpers::GetNumOmpThreads(), 0.0);
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t idx = 0; idx < outer_distribution.size(); idx++)
   {
     const FirstDatatype& first = outer_distribution[idx];
@@ -168,9 +162,7 @@ inline double ComputeDistanceParallel(
   // Make per-thread storage
   std::vector<double> per_thread_storage(
       openmp_helpers::GetNumOmpThreads(), 0.0);
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t idx = 0; idx < outer_distribution.size(); idx++)
   {
     double minimum_distance = std::numeric_limits<double>::infinity();

--- a/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
+++ b/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -125,9 +121,7 @@ inline ClosestPair GetClosestClustersParallel(
 {
   std::vector<ClosestPair> per_thread_closest_clusters(
       static_cast<size_t>(openmp_helpers::GetNumOmpThreads()), ClosestPair());
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t first_cluster_idx = 0; first_cluster_idx < clusters.size();
        first_cluster_idx++)
   {
@@ -279,9 +273,7 @@ inline ClosestPair GetClosestValueToOtherParallel(
 {
   std::vector<ClosestPair> per_thread_closest_value_other(
       static_cast<size_t>(openmp_helpers::GetNumOmpThreads()), ClosestPair());
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t value_idx = 0; value_idx < datapoint_mask.size(); value_idx++)
   {
     // Make sure we're not already clustered

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -12,6 +12,7 @@
 
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
+#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -14,8 +10,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
-#include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
@@ -35,11 +31,7 @@ inline std::vector<int32_t> PerformSingleClusteringIteration(
 {
   std::vector<int32_t> new_cluster_labels(data.size());
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (size_t idx = 0; idx < data.size(); idx++)
   {
     const DataType& datapoint = data.at(idx);
@@ -88,11 +80,7 @@ inline Container ComputeClusterCentersWeighted(
     // Compute the center of each cluster
     Container cluster_centers(static_cast<size_t>(num_clusters));
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-    CRU_UNUSED(use_parallel);
-#endif
+    CRU_OMP_PARALLEL_FOR_IF(use_parallel)
     for (size_t cluster = 0; cluster < clustered_data.size(); cluster++)
     {
       const Container& cluster_data = clustered_data.at(cluster);

--- a/include/common_robotics_utilities/simple_knearest_neighbors.hpp
+++ b/include/common_robotics_utilities/simple_knearest_neighbors.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cstdint>
 #include <functional>
 #include <limits>

--- a/include/common_robotics_utilities/simple_knearest_neighbors.hpp
+++ b/include/common_robotics_utilities/simple_knearest_neighbors.hpp
@@ -81,9 +81,7 @@ inline std::vector<IndexAndDistance> GetKNearestNeighborsParallel(
   else if (items.size() <= static_cast<size_t>(K))
   {
     std::vector<IndexAndDistance> k_nearests(items.size());
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+    CRU_OMP_PARALLEL_FOR
     for (size_t idx = 0; idx < items.size(); idx++)
     {
       const Item& item = items[idx];
@@ -97,9 +95,7 @@ inline std::vector<IndexAndDistance> GetKNearestNeighborsParallel(
     std::vector<std::vector<IndexAndDistance>> per_thread_nearests(
         static_cast<size_t>(openmp_helpers::GetNumOmpThreads()),
         std::vector<IndexAndDistance>(static_cast<size_t>(K)));
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+    CRU_OMP_PARALLEL_FOR
     for (size_t idx = 0; idx < items.size(); idx++)
     {
       const Item& item = items[idx];

--- a/include/common_robotics_utilities/simple_prm_planner.hpp
+++ b/include/common_robotics_utilities/simple_prm_planner.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -14,6 +10,7 @@
 #include <vector>
 
 #include <common_robotics_utilities/maybe.hpp>
+#include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/simple_graph.hpp>
 #include <common_robotics_utilities/simple_graph_search.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
@@ -110,11 +107,7 @@ inline int64_t AddNodeToRoadmap(
   std::vector<std::pair<double, double>> nearest_neighbors_distances(
       nearest_neighbors.size());
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (size_t idx = 0; idx < nearest_neighbors.size(); idx++)
   {
     const auto& nearest_neighbor = nearest_neighbors.at(idx);
@@ -369,11 +362,7 @@ GraphType BuildRoadMap(
   // add_duplicate_states is true, since the check for duplicate states would
   // be a race condition otherwise.
   const bool use_parallel_sampling = use_parallel && add_duplicate_states;
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel_sampling)
-#else
-  CRU_UNUSED(use_parallel_sampling);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel_sampling)
   for (size_t index = 0; index < roadmap_states.size(); index++)
   {
     roadmap_states.at(index) = valid_sample_fn();
@@ -403,9 +392,7 @@ GraphType BuildRoadMap(
 
   // Perform edge validity and distance checks for all nodes, optionally in
   // parallel.
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (int64_t node_index = 0; node_index < roadmap.Size(); ++node_index)
   {
     auto& node = roadmap.GetNodeMutable(node_index);
@@ -528,11 +515,7 @@ inline void UpdateRoadMapEdges(
     throw std::invalid_argument("Provided roadmap has invalid linkage");
   }
 
-#if defined(_OPENMP)
-#pragma omp parallel for if (use_parallel)
-#else
-  CRU_UNUSED(use_parallel);
-#endif
+  CRU_OMP_PARALLEL_FOR_IF(use_parallel)
   for (int64_t current_node_index = 0; current_node_index < roadmap.Size();
        current_node_index++)
   {


### PR DESCRIPTION
In light of the issue identified by #53 with the increasing complexity of OpenMP directives, adds two new macros `CRU_OMP_PARALLEL_FOR` and `CRU_OMP_PARALLEL_FOR_IF(condition)` that encapsulate the complete `#ifdef` + `#pragma` + unused variable handling necessary for OpenMP parallel for loop directives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/55)
<!-- Reviewable:end -->
