### PR TITLE
Remove nearest neighbor early return from RRT planners, remove branch prediction hints

### DIFF
--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -696,14 +696,8 @@ RRTPlanMultiPath(
     const SampleType random_target = sampling_fn();
     statistics["total_samples"] += 1.0;
     // Get the nearest neighbor
-    const int64_t nearest_neighbor_index
-        = nearest_neighbor_fn(tree, random_target);
-    // nearest_neighbor_index < 0 is handled as a special case of early
-    // termination.
-    if (CRU_UNLIKELY(nearest_neighbor_index < 0))
-    {
-      break;
-    }
+    const int64_t nearest_neighbor_index =
+        nearest_neighbor_fn(tree, random_target);
     const StateType& nearest_neighbor =
         tree.GetNodeImmutable(nearest_neighbor_index).GetValueImmutable();
     // Forward propagate towards the goal
@@ -968,16 +962,10 @@ BiRRTPlanMultiPath(
           ? target_tree.GetNodeImmutable(
               target_tree_node_index).GetValueImmutable()
           : state_sampling_fn();
-    // Get the nearest neighbor
-    const int64_t nearest_neighbor_index
-        = nearest_neighbor_fn(active_tree, target_state, start_tree_active);
-    // nearest_neighbor_index < 0 is handled as a sepecial case of early
-    // termination.
-    if (CRU_UNLIKELY(nearest_neighbor_index < 0))
-    {
-      break;
-    }
     statistics["total_samples"] += 1.0;
+    // Get the nearest neighbor
+    const int64_t nearest_neighbor_index =
+        nearest_neighbor_fn(active_tree, target_state, start_tree_active);
     const StateType& nearest_neighbor = active_tree.GetNodeImmutable(
         nearest_neighbor_index).GetValueImmutable();
     // Forward propagate towards the goal

--- a/include/common_robotics_utilities/utility.hpp
+++ b/include/common_robotics_utilities/utility.hpp
@@ -12,27 +12,6 @@
 
 #include <Eigen/Geometry>
 
-// Branch prediction hints
-// Figure out which compiler we have
-#if defined(__clang__)
-  /* Clang/LLVM */
-  #define CRU_LIKELY(x) __builtin_expect(!!(x), 1)
-  #define CRU_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
-  /* Intel ICC/ICPC */
-  #define CRU_LIKELY(x) __builtin_expect(!!(x), 1)
-  #define CRU_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#elif defined(__GNUC__) || defined(__GNUG__)
-  /* GNU GCC/G++ */
-  #define CRU_LIKELY(x) __builtin_expect(!!(x), 1)
-  #define CRU_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#elif defined(_MSC_VER)
-  /* Microsoft Visual Studio */
-  /* MSVC doesn't support branch prediction hints. Use PGO instead. */
-  #define CRU_LIKELY(x) (x)
-  #define CRU_UNLIKELY(x) (x)
-#endif
-
 // Macro to disable unused parameter compiler warnings
 #define CRU_UNUSED(x) (void)(x)
 


### PR DESCRIPTION
Removes early return with nearest neighbor index < 0 from RRT planners, this capability was only used briefly by `uncertainty_planning_core` and was more confusing than helpful.

This was also the last user of the `CRU_LIKELY`/`CRU_UNLIKELY` branch prediction hint macros, which can now be removed. as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/56)
<!-- Reviewable:end -->
