### PR TITLE
Add IsOmpInParallel function

### DIFF
--- a/include/common_robotics_utilities/openmp_helpers.hpp
+++ b/include/common_robotics_utilities/openmp_helpers.hpp
@@ -11,11 +11,21 @@ namespace common_robotics_utilities
 {
 namespace openmp_helpers
 {
-/// Returns if OpenMP is enabled in the build.
+/// Returns true if OpenMP is enabled in the build, false otherwise.
 constexpr bool IsOmpEnabledInBuild()
 {
 #if defined(_OPENMP)
   return true;
+#else
+  return false;
+#endif
+}
+
+/// Returns true if called from within an OpenMP context, false otherwise.
+inline bool IsOmpInParallel()
+{
+#if defined(_OPENMP)
+  return static_cast<bool>(omp_in_parallel());
 #else
   return false;
 #endif
@@ -137,7 +147,7 @@ class ChangeOmpNumThreadsWrapper
 public:
   explicit ChangeOmpNumThreadsWrapper(const int32_t num_threads)
   {
-    if (GetContextNumOmpThreads() > 1)
+    if (IsOmpInParallel())
     {
       throw std::runtime_error(
           "Cannot create ChangeOmpNumThreadsWrapper inside an OpenMP parallel "


### PR DESCRIPTION
Adds `IsOmpInParallel()`, wrapping OpenMP function `omp_in_parallel()`, and uses it within `ChangeOmpNumThreadsWrapper`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/61)
<!-- Reviewable:end -->
