### PR TITLE
Improve RRT/BiRRT propagation index handling to fix bug in parallel BiRRT planner

### DIFF
--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -641,10 +641,11 @@ PlannedPaths<StateType, Container> ExtractSolutionPaths(
 ///     is the index of the parent state, relative to the vector of propagated
 ///     nodes. A negative value means the nearest neighbor in the tree, zero
 ///     means the first propagated node, and so on. NOTE - the relative parent
-///     index *must* be lower than the index in the list of prograted nodes i.e.
-///     the first node must have a negative value, and so on. While complicated,
-///     this structure allows @param forward_propagation_fn to return an entire
-///     subtree at once, which is used for certain multi-outcome planners.
+///     index *must* be lower than the index in the list of propagated nodes
+///     i.e. the first node must have a negative value, and so on. While
+///     complicated, this structure allows @param forward_propagation_fn to
+///     return an entire subtree at once, which is used for certain
+///     multi-outcome planners.
 /// @param state_added_callback_fn callback function called once a state is
 ///     added to the tree, providing a mutable reference to the tree and the
 ///     index of the newly-added state. This can be used, for example, to update
@@ -730,7 +731,10 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
     {
       statistics["successful_samples"] += 1.0;
 
-      // Keep track of the mapping from propagated node to tree index
+      // Keep track of the mapping from propagated node to tree index.
+      // We rely on the bounds check of propagated_index_to_tree_index.at() to
+      // enforce the invariant that relative parent indices refer to prior
+      // nodes, thus this cannot use resize() or equivalent.
       std::vector<int64_t> propagated_index_to_tree_index;
       propagated_index_to_tree_index.reserve(propagated.size());
 
@@ -745,7 +749,7 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
         // relative to the list of propagated nodes. A negative value means the
         // nearest neighbor in the tree, zero means the first propagated node,
         // and so on. NOTE - the relative parent index *must* be lower than the
-        // index in the list of prograted nodes i.e. the first node must have a
+        // index in the list of propagated nodes i.e. the first node must have a
         // negative value, and so on.
         const int64_t& current_relative_parent_index
             = current_propagation.RelativeParentIndex();
@@ -835,7 +839,7 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
 ///     the parent state, relative to the vector of propagated nodes. A negative
 ///     value means the nearest neighbor in the tree, zero means the first
 ///     propagated node, and so on. NOTE - the relative parent index *must* be
-///     lower than the index in the list of prograted nodes i.e. the first node
+///     lower than the index in the list of propagated nodes i.e. the first node
 ///     must have a negative value, and so on. While complicated, this structure
 ///     allows @param forward_propagation_fn to return an entire subtree at
 ///     once, which is used for certain multi-outcome planners.
@@ -1013,7 +1017,10 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
     {
       statistics["successful_samples"] += 1.0;
 
-      // Keep track of the mapping from propagated node to tree index
+      // Keep track of the mapping from propagated node to tree index.
+      // We rely on the bounds check of propagated_index_to_tree_index.at() to
+      // enforce the invariant that relative parent indices refer to prior
+      // nodes, thus this cannot use resize() or equivalent.
       std::vector<int64_t> propagated_index_to_tree_index;
       propagated_index_to_tree_index.reserve(propagated.size());
 
@@ -1028,7 +1035,7 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
         // relative to the list of propagated nodes. A negative value means the
         // nearest neighbor in the tree, zero means the first propagated node,
         // and so on. NOTE - the relative parent index *must* be lower than the
-        // index in the list of prograted nodes i.e. the first node must have a
+        // index in the list of propagated nodes i.e. the first node must have a
         // negative value, and so on.
         const int64_t& current_relative_parent_index
             = current_propagation.RelativeParentIndex();
@@ -1157,10 +1164,11 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
 ///     is the index of the parent state, relative to the vector of propagated
 ///     nodes. A negative value means the nearest neighbor in the tree, zero
 ///     means the first propagated node, and so on. NOTE - the relative parent
-///     index *must* be lower than the index in the list of prograted nodes i.e.
-///     the first node must have a negative value, and so on. While complicated,
-///     this structure allows @param forward_propagation_fn to return an entire
-///     subtree at once, which is used for certain multi-outcome planners.
+///     index *must* be lower than the index in the list of propagated nodes
+///     i.e. the first node must have a negative value, and so on. While
+///     complicated, this structure allows @param forward_propagation_fn to
+///     return an entire subtree at once, which is used for certain
+///     multi-outcome planners.
 /// @param state_added_callback_fn callback function called once a state is
 ///     added to the tree, providing a mutable reference to the tree and the
 ///     index of the newly-added state. This can be used, for example, to update
@@ -1255,7 +1263,7 @@ SingleSolutionPlanningResults<StateType, Container> RRTPlanSinglePath(
 ///     the parent state, relative to the vector of propagated nodes. A negative
 ///     value means the nearest neighbor in the tree, zero means the first
 ///     propagated node, and so on. NOTE - the relative parent index *must* be
-///     lower than the index in the list of prograted nodes i.e. the first node
+///     lower than the index in the list of propagated nodes i.e. the first node
 ///     must have a negative value, and so on. While complicated, this structure
 ///     allows @param forward_propagation_fn to return an entire subtree at
 ///     once, which is used for certain multi-outcome planners.

--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -729,6 +729,12 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
     if (!propagated.empty())
     {
       statistics["successful_samples"] += 1.0;
+
+      // Keep track of the mapping from propagated node to tree index
+      std::vector<int64_t> propagated_index_to_tree_index;
+      propagated_index_to_tree_index.reserve(propagated.size());
+
+      // Go through propagated states
       for (size_t idx = 0; idx < propagated.size(); idx++)
       {
         const PropagatedState<StateType>& current_propagation
@@ -743,28 +749,14 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
         // negative value, and so on.
         const int64_t& current_relative_parent_index
             = current_propagation.RelativeParentIndex();
-        int64_t node_parent_index = nearest_neighbor_index;
-        if (current_relative_parent_index >= 0)
-        {
-          const int64_t current_relative_index = static_cast<int64_t>(idx);
-          if (current_relative_parent_index >= current_relative_index)
-          {
-            throw std::invalid_argument(
-                "Linkage with relative parent index >="
-                " current relative index is invalid");
-          }
-          const int64_t current_relative_offset
-              = current_relative_parent_index - current_relative_index;
-          const int64_t current_nodes_size = tree.Size();
-          // Remember that current_relative_offset is negative!
-          node_parent_index = current_nodes_size + current_relative_offset;
-        }
-        else
-        {
-          // Negative relative parent index means our parent index is the
-          // nearest neighbor index.
-          node_parent_index = nearest_neighbor_index;
-        }
+
+        // Note: all negative indices correspond to the same nearest neighbor
+        // node; further indexing back into the tree is not supported.
+        const int64_t node_parent_index =
+            (current_relative_parent_index >= 0)
+                ? propagated_index_to_tree_index.at(
+                    static_cast<size_t>(current_relative_parent_index))
+                : nearest_neighbor_index;
 
         // Build the new state
         const StateType& current_propagated = current_propagation.State();
@@ -772,6 +764,9 @@ MultipleSolutionPlanningResults<StateType, Container> RRTPlanMultiPath(
         // Add the state to the tree
         const int64_t new_node_index =
             tree.AddNodeAndConnect(current_propagated, node_parent_index);
+
+        // Add the new index to the mapping
+        propagated_index_to_tree_index.emplace_back(new_node_index);
 
         // Call the state added callback
         if (state_added_callback_fn)
@@ -1017,6 +1012,12 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
     if (!propagated.empty())
     {
       statistics["successful_samples"] += 1.0;
+
+      // Keep track of the mapping from propagated node to tree index
+      std::vector<int64_t> propagated_index_to_tree_index;
+      propagated_index_to_tree_index.reserve(propagated.size());
+
+      // Go through propagated states
       for (size_t idx = 0; idx < propagated.size(); idx++)
       {
         const PropagatedState<StateType>& current_propagation
@@ -1031,28 +1032,14 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
         // negative value, and so on.
         const int64_t& current_relative_parent_index
             = current_propagation.RelativeParentIndex();
-        int64_t node_parent_index = nearest_neighbor_index;
-        if (current_relative_parent_index >= 0)
-        {
-          const int64_t current_relative_index = static_cast<int64_t>(idx);
-          if (current_relative_parent_index >= current_relative_index)
-          {
-            throw std::invalid_argument(
-                  "Linkage with relative parent index >="
-                  " current relative index is invalid");
-          }
-          const int64_t current_relative_offset
-              = current_relative_parent_index - current_relative_index;
-          const int64_t current_nodes_size = active_tree.Size();
-          // Remember that current_relative_offset is negative!
-          node_parent_index = current_nodes_size + current_relative_offset;
-        }
-        else
-        {
-          // Negative relative parent index means our parent index is the
-          // nearest neighbor index.
-          node_parent_index = nearest_neighbor_index;
-        }
+
+        // Note: all negative indices correspond to the same nearest neighbor
+        // node; further indexing back into the tree is not supported.
+        const int64_t node_parent_index =
+            (current_relative_parent_index >= 0)
+                ? propagated_index_to_tree_index.at(
+                    static_cast<size_t>(current_relative_parent_index))
+                : nearest_neighbor_index;
 
         // Build the new state
         const StateType& current_propagated = current_propagation.State();
@@ -1060,6 +1047,9 @@ MultipleSolutionPlanningResults<StateType, Container> BiRRTPlanMultiPath(
         // Add the state to the tree
         const int64_t new_node_index = active_tree.AddNodeAndConnect(
             current_propagated, node_parent_index);
+
+        // Add the new index to the mapping
+        propagated_index_to_tree_index.emplace_back(new_node_index);
 
         // Call the state added callback
         if (state_added_callback_fn)


### PR DESCRIPTION
When adding nodes from a propagation, the RRT and BiRRT planner code assumes it is the only mutator of the tree, and thus can compute parent node indices relative to the size of the tree, on the basis that all of the nodes added from a given propagation are the last nodes in the tree. This is not true in the parallel case where multiple planner workers are operating in parallel, and the most-recently-added node in the tree may be from a different worker.

To address this, the planners must maintain a mapping of in-propagation indices to in-tree indices to wire parent-child connections correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/62)
<!-- Reviewable:end -->
