### PR TITLE
Fix UB in {De}SerializeMemcpyableVectorLike use of memcpy

### DIFF
--- a/include/common_robotics_utilities/serialization.hpp
+++ b/include/common_robotics_utilities/serialization.hpp
@@ -445,9 +445,13 @@ inline uint64_t SerializeMemcpyableVectorLike(
       sizeof(T) * static_cast<size_t>(vec_to_serialize.size());
   const size_t previous_buffer_size = buffer.size();
   buffer.resize(previous_buffer_size + serialized_length, 0x00);
-  // Serialize the contained items
-  memcpy(&buffer[previous_buffer_size],
-         vec_to_serialize.data(), serialized_length);
+  // Only perform additional actions if nonempty, since memcpy on nullptr
+  // (encountered if a vector is empty) is undefined behavior.
+  if (size > 0)
+  {
+    memcpy(&buffer[previous_buffer_size],
+           vec_to_serialize.data(), serialized_length);
+  }
   // Figure out how many bytes were written
   const uint64_t end_buffer_size = buffer.size();
   const uint64_t bytes_written = end_buffer_size - start_buffer_size;
@@ -473,8 +477,13 @@ DeserializeMemcpyableVectorLike(
     throw std::invalid_argument("Not enough room in the provided buffer");
   }
   VectorLike deserialized(size);
-  memcpy(deserialized.data(), &buffer[current_position], serialized_length);
-  current_position += serialized_length;
+  // Only perform additional actions if nonempty, since memcpy on nullptr
+  // (encountered if a vector is empty) is undefined behavior.
+  if (size > 0)
+  {
+    memcpy(deserialized.data(), &buffer[current_position], serialized_length);
+    current_position += serialized_length;
+  }
   // Figure out how many bytes were read
   const uint64_t bytes_read = current_position - starting_offset;
   return MakeDeserialized(deserialized, bytes_read);

--- a/include/common_robotics_utilities/serialization.hpp
+++ b/include/common_robotics_utilities/serialization.hpp
@@ -445,8 +445,8 @@ inline uint64_t SerializeMemcpyableVectorLike(
       sizeof(T) * static_cast<size_t>(vec_to_serialize.size());
   const size_t previous_buffer_size = buffer.size();
   buffer.resize(previous_buffer_size + serialized_length, 0x00);
-  // Only perform additional actions if nonempty, since memcpy on nullptr
-  // (encountered if a vector is empty) is undefined behavior.
+  // Only memcpy if a non-zero number of bytes will be copied, since memcpy on
+  // nullptr dst/src (encountered if a vector is empty) is undefined behavior.
   if (size > 0)
   {
     memcpy(&buffer[previous_buffer_size],
@@ -477,13 +477,13 @@ DeserializeMemcpyableVectorLike(
     throw std::invalid_argument("Not enough room in the provided buffer");
   }
   VectorLike deserialized(size);
-  // Only perform additional actions if nonempty, since memcpy on nullptr
-  // (encountered if a vector is empty) is undefined behavior.
+  // Only memcpy if a non-zero number of bytes will be copied, since memcpy on
+  // nullptr dst/src (encountered if a vector is empty) is undefined behavior.
   if (size > 0)
   {
     memcpy(deserialized.data(), &buffer[current_position], serialized_length);
-    current_position += serialized_length;
   }
+  current_position += serialized_length;
   // Figure out how many bytes were read
   const uint64_t bytes_read = current_position - starting_offset;
   return MakeDeserialized(deserialized, bytes_read);


### PR DESCRIPTION
`memcpy` with a null `dst` and/or `src` is undefined, even if the size to be copied is zero. This UB was identified while upgrading from Clang 12 to Clang 14 in Drake.

FYI @jwnimmer-tri

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/66)
<!-- Reviewable:end -->
