### PR TITLE
Factor out and fix thread range calculation

### DIFF
--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 #include <stdlib.h>
 
 #include <common_robotics_utilities/utility.hpp>
@@ -236,6 +237,54 @@ GTEST_TEST(UtilityTest, IsFutureReadyTest)
   EXPECT_FALSE(utility::IsFutureReady(wait_future));
   wait_future.wait();
   EXPECT_TRUE(utility::IsFutureReady(wait_future));
+}
+
+GTEST_TEST(UtilityTest, CalcThreadRangeStartAndEndTest)
+{
+  // Parameter sanity testing
+  // range_start > range_end throws
+  EXPECT_THROW(
+      utility::CalcThreadRangeStartAndEnd(1, 0, 1, 1), std::invalid_argument);
+  // num_threads < 1 throws
+  EXPECT_THROW(
+      utility::CalcThreadRangeStartAndEnd(0, 1, 0, 1), std::invalid_argument);
+  // thread_num < 0 throws
+  EXPECT_THROW(
+      utility::CalcThreadRangeStartAndEnd(1, 0, 1, -1), std::invalid_argument);
+  // thread_num >= num_threads throws
+  EXPECT_THROW(
+      utility::CalcThreadRangeStartAndEnd(1, 0, 1, 1), std::invalid_argument);
+
+  const std::vector<int64_t> range_starts = {0, 25, 100, 2000, 9001};
+  const std::vector<int64_t> range_sizes = {0, 1, 5, 10, 15, 100, 1000, 9001};
+  const std::vector<int64_t> thread_counts = {1, 2, 5, 10, 25, 100};
+
+  for (const int64_t range_start : range_starts)
+  {
+    for (const int64_t range_size : range_sizes)
+    {
+      for (const int64_t num_threads : thread_counts)
+      {
+        int64_t previous_range_end = range_start;
+
+        for (int64_t thread_num = 0; thread_num < num_threads; thread_num++)
+        {
+          const auto start_and_end = utility::CalcThreadRangeStartAndEnd(
+              range_start, range_start + range_size, num_threads, thread_num);
+          const int64_t thread_range_start = start_and_end.first;
+          const int64_t thread_range_end = start_and_end.second;
+
+          EXPECT_EQ(previous_range_end, thread_range_start);
+          EXPECT_GE(thread_range_end, thread_range_start);
+          EXPECT_LE(thread_range_end, range_start + range_size);
+
+          previous_range_end = thread_range_end;
+        }
+
+        EXPECT_EQ(previous_range_end, range_start + range_size);
+      }
+    }
+  }
 }
 }  // namespace utility_test
 }  // namespace common_robotics_utilities


### PR DESCRIPTION
Factors out per-thread range calculation as needed by [VGT #44](https://github.com/calderpg/voxelized_geometry_tools/pull/44). Additionally, fixes bug in range start calculation for ranges not starting at zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/69)
<!-- Reviewable:end -->
