### PR TITLE
Add CRU_NAMESPACE_{BEGIN,END} annotations

### DIFF
--- a/CMakeLists.txt.ros1
+++ b/CMakeLists.txt.ros1
@@ -81,6 +81,7 @@ add_library(${PROJECT_NAME}
             include/${PROJECT_NAME}/base64_helpers.hpp
             include/${PROJECT_NAME}/color_builder.hpp
             include/${PROJECT_NAME}/conversions.hpp
+            include/${PROJECT_NAME}/cru_namespace.hpp
             include/${PROJECT_NAME}/dynamic_spatial_hashed_voxel_grid.hpp
             include/${PROJECT_NAME}/gaussian_distributions.hpp
             include/${PROJECT_NAME}/math.hpp

--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
             include/${PROJECT_NAME}/base64_helpers.hpp
             include/${PROJECT_NAME}/color_builder.hpp
             include/${PROJECT_NAME}/conversions.hpp
+            include/${PROJECT_NAME}/cru_namespace.hpp
             include/${PROJECT_NAME}/dynamic_spatial_hashed_voxel_grid.hpp
             include/${PROJECT_NAME}/gaussian_distributions.hpp
             include/${PROJECT_NAME}/math.hpp

--- a/include/common_robotics_utilities/base64_helpers.hpp
+++ b/include/common_robotics_utilities/base64_helpers.hpp
@@ -4,12 +4,16 @@
 #include <string>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
+
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace base64_helpers
 {
 std::vector<uint8_t> Decode(const std::string& encoded);
 
 std::string Encode(const std::vector<uint8_t>& binary);
 }  // namespace base64_helpers
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/color_builder.hpp
+++ b/include/common_robotics_utilities/color_builder.hpp
@@ -3,10 +3,12 @@
 #include <cmath>
 #include <cstdint>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace color_builder
 {
 /// Convert @param hexval color channel to float.
@@ -304,4 +306,5 @@ inline ColorType LookupUniqueColor(const uint32_t color_code,
   }
 }
 }  // namespace color_builder
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/conversions.hpp
+++ b/include/common_robotics_utilities/conversions.hpp
@@ -3,9 +3,11 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace conversions
 {
 Eigen::Quaterniond QuaternionFromRPY(const double R,
@@ -76,4 +78,5 @@ Eigen::Quaterniond StdVectorDoubleToEigenQuaterniond(
 std::vector<double> EigenQuaterniondToStdVectorDouble(
     const Eigen::Quaterniond& quat);
 }  // namespace conversions
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/cru_namespace.hpp
+++ b/include/common_robotics_utilities/cru_namespace.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+/** Downstream projects can adjust these macros to tweak the project namespace.
+
+When set, they should refer to a C++ inline namespace:
+ https://en.cppreference.com/w/cpp/language/namespace#Inline_namespaces
+
+The inline namespace provides symbol versioning to allow multiple copies of
+common_robotics_utilities to be linked into the same image. In many cases,
+the namespace will also be marked hidden so that linker symbols are private.
+
+Example:
+  #define CRU_NAMESPACE_BEGIN \
+      inline namespace v1 __attribute__ ((visibility ("hidden"))) {
+  #define CRU_NAMESPACE_END }
+*/
+
+#ifndef CRU_NAMESPACE_BEGIN
+# define CRU_NAMESPACE_BEGIN inline namespace v1 {
+#endif
+
+#ifndef CRU_NAMESPACE_END
+# define CRU_NAMESPACE_END }
+#endif

--- a/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
+++ b/include/common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/serialization.hpp>
 #include <common_robotics_utilities/utility.hpp>
@@ -16,6 +17,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace voxel_grid
 {
 class ChunkRegion
@@ -1134,6 +1136,7 @@ public:
       : DynamicSpatialHashedVoxelGridBase<T, BackingStore>() {}
 };
 }  // namespace voxel_grid
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities
 
 namespace std

--- a/include/common_robotics_utilities/gaussian_distributions.hpp
+++ b/include/common_robotics_utilities/gaussian_distributions.hpp
@@ -5,9 +5,11 @@
 #include <random>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace gaussian_distributions
 {
 /// See https://people.sc.fsu.edu/~jburkardt/presentations/truncated_normal.pdf
@@ -435,4 +437,5 @@ public:
   }
 };
 }  // namespace gaussian_distributions
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/math.hpp
+++ b/include/common_robotics_utilities/math.hpp
@@ -6,10 +6,12 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace math
 {
 ///////////////////////////////////////////////////////////////
@@ -662,4 +664,5 @@ public:
 
 Hyperplane FitPlaneToPoints(const std::vector<Eigen::VectorXd>& points);
 }  // namespace math
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/maybe.hpp
+++ b/include/common_robotics_utilities/maybe.hpp
@@ -4,9 +4,11 @@
 #include <type_traits>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace internal
 {
 /// Helper type for OwningMaybe<T> that stores one of two values without
@@ -246,4 +248,5 @@ public:
 
   explicit operator bool() const { return HasValue(); }
 };
-}
+CRU_NAMESPACE_END
+}  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/openmp_helpers.hpp
+++ b/include/common_robotics_utilities/openmp_helpers.hpp
@@ -9,8 +9,11 @@
 #include <omp.h>
 #endif
 
+#include <common_robotics_utilities/cru_namespace.hpp>
+
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace openmp_helpers
 {
 /// Returns true if OpenMP is enabled in the build, false otherwise.
@@ -221,6 +224,7 @@ private:
 };
 
 }  // namespace openmp_helpers
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities
 
 /// Macro to stringify tokens for the purposes of the below macros.

--- a/include/common_robotics_utilities/path_processing.hpp
+++ b/include/common_robotics_utilities/path_processing.hpp
@@ -8,11 +8,13 @@
 #include <stdexcept>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/math.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace path_processing
 {
 template<typename Configuration, typename Container=std::vector<Configuration>>
@@ -334,4 +336,5 @@ inline Container ResamplePath(
   return resampled_path;
 }
 }  // namespace path_processing
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/print.hpp
+++ b/include/common_robotics_utilities/print.hpp
@@ -16,10 +16,12 @@
 #include <utility>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace print
 {
 // Base template function for printing types
@@ -962,4 +964,5 @@ inline std::string Print(
   return strm.str();
 }
 }  // namespace print
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/random_rotation_generator.hpp
+++ b/include/common_robotics_utilities/random_rotation_generator.hpp
@@ -6,9 +6,11 @@
 #include <random>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace random_rotation_generator
 {
 /// Generator for uniform random quaternions and Euler angles.
@@ -88,4 +90,5 @@ public:
   }
 };
 }  // namespace random_rotation_generator
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/ros_conversions.hpp
+++ b/include/common_robotics_utilities/ros_conversions.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/math.hpp>
 
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
@@ -19,6 +20,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace ros_conversions
 {
 
@@ -116,4 +118,5 @@ std::vector<GeometryPose> VectorIsometry3dToVectorGeometryPose(
 std::vector<GeometryTransform> VectorIsometry3dToVectorGeometryTransform(
     const common_robotics_utilities::math::VectorIsometry3d& vector_eigen);
 }  // namespace ros_conversions
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/ros_helpers.hpp
+++ b/include/common_robotics_utilities/ros_helpers.hpp
@@ -4,6 +4,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
+
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
 #include <rosidl_runtime_cpp/traits.hpp>
 // On pre-Humble distributions, a single message header is included to ensure
@@ -47,6 +49,7 @@ operator<<(ostream& os, const T& message)
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace ros_helpers
 {
 #if COMMON_ROBOTICS_UTILITIES__SUPPORTED_ROS_VERSION == 2
@@ -79,4 +82,5 @@ inline void SetMessageTimestamps(
 }
 
 }  // namespace ros_helpers
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/serialization.hpp
+++ b/include/common_robotics_utilities/serialization.hpp
@@ -9,9 +9,11 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace serialization
 {
 template<typename T>
@@ -1114,4 +1116,5 @@ inline Deserialized<SetLike> DeserializeNetworkSetLike(
   return MakeDeserialized(deserialized, bytes_read);
 }
 }  // namespace serialization
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_astar_search.hpp
+++ b/include/common_robotics_utilities/simple_astar_search.hpp
@@ -11,10 +11,12 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_astar_search
 {
 /// Wrapper for P-Queue elements used in A* search. Contains the unique node_id,
@@ -521,4 +523,5 @@ inline AstarResult<T, Container> PerformAstarSearch(
       limit_pqueue_duplicates, hasher, equaler);
 }
 }  // namespace simple_astar_search
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_dtw.hpp
+++ b/include/common_robotics_utilities/simple_dtw.hpp
@@ -7,9 +7,11 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_dtw
 {
 template<typename FirstDatatype, typename SecondDatatype,
@@ -128,4 +130,5 @@ inline double EvaluateWarpingCost(
       first_sequence, second_sequence, distance_fn);
 }
 }  // namespace simple_dtw
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_graph.hpp
+++ b/include/common_robotics_utilities/simple_graph.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/print.hpp>
 #include <common_robotics_utilities/serialization.hpp>
@@ -16,6 +17,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_graph
 {
 /// Directed weighted graph edge.
@@ -984,5 +986,6 @@ inline std::ostream& operator<< (
   return stream;
 }
 }  // namespace simple_graph
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities
 

--- a/include/common_robotics_utilities/simple_graph_search.hpp
+++ b/include/common_robotics_utilities/simple_graph_search.hpp
@@ -10,12 +10,14 @@
 #include <utility>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/simple_astar_search.hpp>
 #include <common_robotics_utilities/simple_graph.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_graph_search
 {
 /// Wrapper class to store the results of performing Dijkstra's search on a
@@ -587,4 +589,5 @@ inline AstarIndexResult PerformAstarSearch(
       distance_function, heuristic_function, limit_pqueue_duplicates);
 }
 }  // namespace simple_graph_search
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_hausdorff_distance.hpp
+++ b/include/common_robotics_utilities/simple_hausdorff_distance.hpp
@@ -7,10 +7,12 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 /// Compute Hausdorff distance between two distributions.
 /// "The Hausdorff distance is the longest distance you can be forced to travel
 /// by an adversary who chooses a point in one of the two sets, from where you
@@ -299,4 +301,5 @@ inline double ComputeDistance(
   }
 }
 }  // namespace simple_hausdorff_distance
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
+++ b/include/common_robotics_utilities/simple_hierarchical_clustering.hpp
@@ -9,11 +9,13 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/math.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 /// Implementation of hierarchical clustering, in both Single-link and
 /// Complete-link forms. Unlike some implementations, this does not produce the
 /// dendrogram of clusters - it only returns the accumulated clusters up to the
@@ -706,4 +708,5 @@ ClusteringResult<DataType, Container> Cluster(
       data, distance_matrix, max_cluster_distance, strategy, parallelism);
 }
 }  // namespace simple_hierarchical_clustering
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_kmeans_clustering.hpp
+++ b/include/common_robotics_utilities/simple_kmeans_clustering.hpp
@@ -10,12 +10,14 @@
 #include <unordered_map>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 /// Simple implementation of K-means clustering.
 namespace simple_kmeans_clustering
 {
@@ -325,4 +327,5 @@ std::vector<int32_t> Cluster(
       prng_seed, do_preliminary_clustering, parallelism, logging_fn);
 }
 }  // namespace simple_kmeans_clustering
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_knearest_neighbors.hpp
+++ b/include/common_robotics_utilities/simple_knearest_neighbors.hpp
@@ -9,11 +9,13 @@
 #include <utility>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_knearest_neighbors
 {
 /// Type to wrap an index and its corresponding distance.
@@ -346,4 +348,5 @@ inline std::vector<IndexAndDistance> GetKNearestNeighbors(
       items, 0, items.size(), current, distance_fn, K, parallelism);
 }
 }  // namespace simple_knearest_neighbors
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_prm_planner.hpp
+++ b/include/common_robotics_utilities/simple_prm_planner.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/simple_graph.hpp>
@@ -17,6 +18,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_prm_planner
 {
 /// Enum to select the direction of node-to-graph connection. If the "distance"
@@ -864,4 +866,5 @@ QueryPath(
   }
 }
 }  // namespace simple_prm_planner
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_prngs.hpp
+++ b/include/common_robotics_utilities/simple_prngs.hpp
@@ -5,8 +5,11 @@
 #include <cstdint>
 #include <limits>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
+
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_prngs
 {
 /// Implementation of the "Split-Mix 64" PRNG.
@@ -191,4 +194,5 @@ public:
   }
 };
 }  // namespace simple_prngs
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_robot_model_interface.hpp
+++ b/include/common_robotics_utilities/simple_robot_model_interface.hpp
@@ -3,10 +3,12 @@
 #include <string>
 #include <Eigen/Geometry>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/math.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_robot_model_interface
 {
 /// This is basically the absolute minimal robot model interface needed to do
@@ -116,4 +118,5 @@ public:
       const Eigen::Vector4d& link_relative_point) const = 0;
 };
 }  // namespace simple_robot_model_interface
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_rrt_planner.hpp
+++ b/include/common_robotics_utilities/simple_rrt_planner.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/serialization.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
@@ -20,6 +21,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_rrt_planner
 {
 /// Basic templated tree node for use in RRT planners. Node stores a templated
@@ -1949,4 +1951,5 @@ MakeKinematicBiRRTConnectPropagationFunction(
   return forward_propagation_fn;
 }
 }  // namespace simple_rrt_planner
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/simple_task_planner.hpp
+++ b/include/common_robotics_utilities/simple_task_planner.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/simple_astar_search.hpp>
 #include <common_robotics_utilities/simple_knearest_neighbors.hpp>
@@ -19,6 +20,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace simple_task_planner
 {
 template<typename State>
@@ -552,4 +554,5 @@ Container PerformSingleTaskExecution(
       user_post_outcome_callback_fn);
 }
 }  // namespace simple_task_planner
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/time_optimal_trajectory_parametrization.hpp
+++ b/include/common_robotics_utilities/time_optimal_trajectory_parametrization.hpp
@@ -5,9 +5,11 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace time_optimal_trajectory_parametrization
 {
 /// Stores a position+velocity+time point in a trajectory.
@@ -67,4 +69,5 @@ std::unique_ptr<PositionVelocityTrajectoryInterface> ParametrizePathTOTP(
     const Eigen::VectorXd& max_acceleration,
     const double max_deviation = 0.0, const double timestep = 0.001);
 }  // namespace time_optimal_trajectory_parametrization
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/utility.hpp
+++ b/include/common_robotics_utilities/utility.hpp
@@ -13,12 +13,14 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 
 // Macro to disable unused parameter compiler warnings
 #define CRU_UNUSED(x) (void)(x)
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace utility
 {
 /// Given a range defined by @param range_start and @param range_end and the
@@ -101,6 +103,7 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest)
   hash_combine(seed, rest...);
 }
 }  // namespace utility
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities
 
 // Macro to construct std::hash<type> specializations for simple types that
@@ -130,6 +133,7 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest)
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace utility
 {
 /// Signature of a basic logging function.
@@ -555,4 +559,5 @@ inline MapLike MakeFromKeysAndValues(
   }
 }
 }  // namespace utility
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/include/common_robotics_utilities/voxel_grid.hpp
+++ b/include/common_robotics_utilities/voxel_grid.hpp
@@ -9,12 +9,14 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/cru_namespace.hpp>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/serialization.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace voxel_grid
 {
 class GridIndex
@@ -1356,6 +1358,7 @@ inline std::ostream& operator<<(std::ostream& strm, const GridIndex& index)
   return strm;
 }
 }  // namespace voxel_grid
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities
 
 namespace std

--- a/include/common_robotics_utilities/zlib_helpers.hpp
+++ b/include/common_robotics_utilities/zlib_helpers.hpp
@@ -4,8 +4,11 @@
 #include <string>
 #include <vector>
 
+#include <common_robotics_utilities/cru_namespace.hpp>
+
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace zlib_helpers
 {
 std::vector<uint8_t> DecompressBytes(const std::vector<uint8_t>& compressed);
@@ -17,4 +20,5 @@ std::vector<uint8_t> LoadFromFileAndDecompress(const std::string& filename);
 void CompressAndWriteToFile(
     const std::vector<uint8_t>& uncompressed, const std::string& filename);
 }  // namespace zlib_helpers
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/base64_helpers.cpp
+++ b/src/common_robotics_utilities/base64_helpers.cpp
@@ -7,6 +7,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace base64_helpers
 {
 /// Implementations derived from post at http://stackoverflow.com/a/41094722
@@ -111,4 +112,5 @@ std::string Encode(const std::vector<uint8_t>& binary)
   return encoded;
 }
 }  // namespace base64_helpers
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/conversions.cpp
+++ b/src/common_robotics_utilities/conversions.cpp
@@ -6,6 +6,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace conversions
 {
 Eigen::Quaterniond QuaternionFromRPY(const double R,
@@ -210,4 +211,5 @@ std::vector<double> EigenQuaterniondToStdVectorDouble(
   return std::vector<double>{quat.x(), quat.y(), quat.z(), quat.w()};
 }
 }  // namespace conversions
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/math.cpp
+++ b/src/common_robotics_utilities/math.cpp
@@ -5,6 +5,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace math
 {
 bool Equal3d(const Eigen::Vector3d& v1, const Eigen::Vector3d& v2)
@@ -1030,4 +1031,5 @@ Hyperplane FitPlaneToPoints(const std::vector<Eigen::VectorXd>& points)
   return Hyperplane(centroid, normal_vector);
 }
 }  // namespace math
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/ros_conversions.cpp
+++ b/src/common_robotics_utilities/ros_conversions.cpp
@@ -7,6 +7,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace ros_conversions
 {
 Eigen::Vector3d GeometryPointToEigenVector3d(
@@ -298,4 +299,5 @@ std::vector<GeometryTransform> VectorIsometry3dToVectorGeometryTransform(
   return vector_geom;
 }
 }  // namespace ros_conversions
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/serialization.cpp
+++ b/src/common_robotics_utilities/serialization.cpp
@@ -8,6 +8,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace serialization
 {
 constexpr uint64_t SerializedSizeVector2d()
@@ -255,4 +256,5 @@ Deserialized<Eigen::Isometry3d> DeserializeIsometry3d(
   return MakeDeserialized(temp_value, SerializedSizeIsometry3d());
 }
 }  // namespace serialization
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/time_optimal_trajectory_parametrization.cpp
+++ b/src/common_robotics_utilities/time_optimal_trajectory_parametrization.cpp
@@ -51,6 +51,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace time_optimal_trajectory_parametrization
 {
 namespace {
@@ -1192,4 +1193,5 @@ std::unique_ptr<PositionVelocityTrajectoryInterface> ParametrizePathTOTP(
           path, max_velocity, max_acceleration, max_deviation, timestep));
 }
 }  // namespace time_optimal_trajectory_parametrization
+CRU_NAMESPACE_END
 }  // namespace common_robotics_utilities

--- a/src/common_robotics_utilities/zlib_helpers.cpp
+++ b/src/common_robotics_utilities/zlib_helpers.cpp
@@ -11,6 +11,7 @@
 
 namespace common_robotics_utilities
 {
+CRU_NAMESPACE_BEGIN
 namespace zlib_helpers
 {
 std::vector<uint8_t> DecompressBytes(const std::vector<uint8_t>& compressed)
@@ -160,4 +161,5 @@ void CompressAndWriteToFile(
   output_file.close();
 }
 } // namespace zlib_helpers
+CRU_NAMESPACE_END
 } // namespace common_robotics_utilities


### PR DESCRIPTION
This allows downstream projects to vary the symbol names to avoid ODR compatibility headaches (https://github.com/RobotLocomotion/drake/issues/17231).

See https://github.com/RobotLocomotion/drake/pull/19893 for Drake CI testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/70)
<!-- Reviewable:end -->
