### PR TITLE
Fix bug in par-for exception handling

### DIFF
--- a/include/common_robotics_utilities/utility.hpp
+++ b/include/common_robotics_utilities/utility.hpp
@@ -85,6 +85,44 @@ namespace common_robotics_utilities
 CRU_NAMESPACE_BEGIN
 namespace utility
 {
+/// Helper type to run the provided function on scope exit via RAII.
+class OnScopeExit
+{
+public:
+  // OnScopeExit does not allow copy/move/assign operations.
+  OnScopeExit(const OnScopeExit& other) = delete;
+
+  OnScopeExit(OnScopeExit&& other) = delete;
+
+  OnScopeExit& operator=(const OnScopeExit& other) = delete;
+
+  OnScopeExit& operator=(OnScopeExit&& other) = delete;
+
+  explicit OnScopeExit(const std::function<void(void)>& on_scope_exit)
+      : on_scope_exit_(on_scope_exit)
+  {
+    if (!on_scope_exit_)
+    {
+      throw std::invalid_argument("on_scope_exit must not be nullptr");
+    }
+  }
+
+  ~OnScopeExit()
+  {
+    if (on_scope_exit_)
+    {
+      on_scope_exit_();
+    }
+  }
+
+  bool IsEnabled() const { return (on_scope_exit_ != nullptr); }
+
+  void Disable() { on_scope_exit_ = {}; }
+
+private:
+  std::function<void(void)> on_scope_exit_;
+};
+
 /// Signature of a basic logging function.
 using LoggingFunction = std::function<void(const std::string&)>;
 

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -238,6 +238,31 @@ GTEST_TEST(UtilityTest, IsFutureReadyTest)
   wait_future.wait();
   EXPECT_TRUE(utility::IsFutureReady(wait_future));
 }
+
+GTEST_TEST(UtilityTest, OnScopeExitTest)
+{
+  int test_val = 0;
+
+  const auto on_exit_fn = [&test_val]() { test_val = 10; };
+
+  EXPECT_EQ(test_val, 0);
+  {
+    const utility::OnScopeExit on_exit(on_exit_fn);
+    EXPECT_TRUE(on_exit.IsEnabled());
+  }
+  EXPECT_EQ(test_val, 10);
+
+  test_val = 0;
+
+  EXPECT_EQ(test_val, 0);
+  {
+    utility::OnScopeExit on_exit(on_exit_fn);
+    EXPECT_TRUE(on_exit.IsEnabled());
+    on_exit.Disable();
+    EXPECT_FALSE(on_exit.IsEnabled());
+  }
+  EXPECT_EQ(test_val, 0);
+}
 }  // namespace utility_test
 }  // namespace common_robotics_utilities
 


### PR DESCRIPTION
Bug in #74 meant that exceptions thrown in `async`-based dynamic parallel-for loop could result in the condition variable not being notified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/common_robotics_utilities/75)
<!-- Reviewable:end -->
